### PR TITLE
PCGDataAsset collection improvements

### DIFF
--- a/Resources/Icons/PCGEx_Editor_PCGDA_Actor.svg
+++ b/Resources/Icons/PCGEx_Editor_PCGDA_Actor.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="icons" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #fff;
+      }
+
+      .cls-2 {
+        opacity: .25;
+      }
+
+      .cls-3 {
+        fill: #f0d41f;
+      }
+    </style>
+  </defs>
+  <circle cx="52" cy="53" r="30.34"/>
+  <circle class="cls-1" cx="50" cy="50" r="30.34"/>
+  <path class="cls-2" d="M20.33,43.65c-.44,2.05-.67,4.17-.67,6.35,0,16.76,13.59,30.34,30.34,30.34,2.09,0,4.12-.21,6.09-.61-18.37-3.08-32.85-17.65-35.76-36.08Z"/>
+  <ellipse class="cls-3" cx="62.77" cy="34.82" rx="6.64" ry="12.87" transform="translate(-2.4 64.9) rotate(-53.8)"/>
+</svg>

--- a/Source/PCGExCollections/Private/Collections/PCGExActorCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExActorCollection.cpp
@@ -18,6 +18,8 @@
 #include "Engine/World.h"
 #include "Helpers/PCGExActorHelpers.h"
 #include "Helpers/PCGExActorPropertyDelta.h"
+#include "Helpers/PCGExCollectionsHelpers.h"
+#include "Helpers/PCGExStreamingHelpers.h"
 #include "UObject/UObjectThreadContext.h"
 
 // Static-init type registration: TypeId=Actor, parent=Base
@@ -145,52 +147,35 @@ void FPCGExActorCollectionEntry::UpdateStaging(const UPCGExAssetCollection* Owni
 	}
 
 #if WITH_EDITOR
-	// Delta capture from a placed actor in a level
-	if (DeltaSourceLevel.ToSoftObjectPath().IsValid() && DeltaSourceActorName != NAME_None)
+	// Delta capture from a placed actor in a level. An unreachable actor keeps the previous delta.
+	if (DeltaSourceActor.ToSoftObjectPath().IsValid())
 	{
-		TSharedPtr<FStreamableHandle> LevelHandle = PCGExHelpers::LoadBlocking_AnyThread(DeltaSourceLevel.ToSoftObjectPath());
-
-		if (const UWorld* World = DeltaSourceLevel.Get())
+		TSharedPtr<FStreamableHandle> LevelHandle;
+		FString Failure;
+		if (AActor* FoundActor = PCGExCollections::ResolveLevelActor(DeltaSourceActor.ToSoftObjectPath(), LevelHandle, &Failure))
 		{
-			AActor* FoundActor = nullptr;
-			if (World->PersistentLevel)
+			if (Actor.Get() && FoundActor->IsA(Actor.Get()))
 			{
-				for (AActor* LevelActor : World->PersistentLevel->Actors)
-				{
-					if (LevelActor && LevelActor->GetFName() == DeltaSourceActorName)
-					{
-						FoundActor = LevelActor;
-						break;
-					}
-				}
+				DeltaCollateralPaths.Reset();
+				SerializedPropertyDelta = PCGExActorDelta::SerializeActorDelta(FoundActor, &DeltaCollateralPaths);
 			}
-
-			if (FoundActor)
+			else if (!Actor.ToSoftObjectPath().IsValid())
 			{
-				if (Actor.Get() && FoundActor->IsA(Actor.Get()))
-				{
-					DeltaCollateralPaths.Reset();
-					SerializedPropertyDelta = PCGExActorDelta::SerializeActorDelta(FoundActor, &DeltaCollateralPaths);
-				}
-				else if (!Actor.ToSoftObjectPath().IsValid())
-				{
-					// Auto-populate Actor class from the found actor
-					Actor = TSoftClassPtr<AActor>(FSoftClassPath(FoundActor->GetClass()));
-					Staging.Path = Actor.ToSoftObjectPath();
-					DeltaCollateralPaths.Reset();
-					SerializedPropertyDelta = PCGExActorDelta::SerializeActorDelta(FoundActor, &DeltaCollateralPaths);
-				}
-				else
-				{
-					UE_LOG(LogPCGEx, Warning, TEXT("Delta source actor class mismatch -- expected '%s', found '%s'"),
-					       *Actor.ToSoftObjectPath().ToString(), *FSoftClassPath(FoundActor->GetClass()).ToString());
-				}
+				// Auto-populate Actor class from the found actor
+				Actor = TSoftClassPtr<AActor>(FSoftClassPath(FoundActor->GetClass()));
+				Staging.Path = Actor.ToSoftObjectPath();
+				DeltaCollateralPaths.Reset();
+				SerializedPropertyDelta = PCGExActorDelta::SerializeActorDelta(FoundActor, &DeltaCollateralPaths);
 			}
 			else
 			{
-				UE_LOG(LogPCGEx, Warning, TEXT("Delta source actor '%s' not found in level '%s'"),
-				       *DeltaSourceActorName.ToString(), *DeltaSourceLevel.ToSoftObjectPath().ToString());
+				UE_LOG(LogPCGEx, Warning, TEXT("Delta source actor class mismatch -- expected '%s', found '%s'"),
+				       *Actor.ToSoftObjectPath().ToString(), *FSoftClassPath(FoundActor->GetClass()).ToString());
 			}
+		}
+		else
+		{
+			UE_LOG(LogPCGEx, Warning, TEXT("Delta source actor unavailable: %s -- keeping the previous delta."), *Failure);
 		}
 
 		PCGExHelpers::SafeReleaseHandle(LevelHandle);
@@ -205,6 +190,27 @@ void FPCGExActorCollectionEntry::SetAssetPath(const FSoftObjectPath& InPath)
 {
 	FPCGExAssetCollectionEntry::SetAssetPath(InPath);
 	Actor = TSoftClassPtr<AActor>(InPath);
+}
+
+bool FPCGExActorCollectionEntry::OnHostPostLoad(UPCGExAssetCollection* Host)
+{
+	const bool bHasLegacyPair = !DeltaSourceLevel_DEPRECATED.IsNull() && DeltaSourceActorName_DEPRECATED != NAME_None;
+	if (!bHasLegacyPair)
+	{
+		return false;
+	}
+
+	// The name lookup this replaces was never more exact than the persistent-level path; an actor
+	// renamed since the last save fails loudly at the next staging instead of silently matching.
+	if (DeltaSourceActor.IsNull())
+	{
+		DeltaSourceActor = TSoftObjectPtr<AActor>(FSoftObjectPath(
+			DeltaSourceLevel_DEPRECATED.ToSoftObjectPath().GetAssetPath(),
+			FString::Printf(TEXT("PersistentLevel.%s"), *DeltaSourceActorName_DEPRECATED.ToString())));
+	}
+	DeltaSourceLevel_DEPRECATED.Reset();
+	DeltaSourceActorName_DEPRECATED = NAME_None;
+	return true;
 }
 
 #if WITH_EDITOR
@@ -244,10 +250,9 @@ void FPCGExActorCollectionEntry::EDITOR_Sanitize()
 namespace PCGExActorCollectionInternal
 {
 	// Resolve the donor actor for a given entry: prefer an explicit live instance from the
-	// caller, fall back to loading entry.DeltaSourceLevel and finding entry.DeltaSourceActorName.
-	// Class match on the level-loaded path mirrors the existing UpdateStaging delta-capture
-	// constraint -- prevents silently scanning the wrong actor when multiple actors share a
-	// name across classes.
+	// caller, fall back to resolving entry.DeltaSourceActor. Class match on the resolved path
+	// mirrors the UpdateStaging delta-capture constraint -- a re-pointed reference must not
+	// silently feed another class's properties into the schema.
 	AActor* ResolveDonorActor(
 		const FPCGExActorCollectionEntry& Entry,
 		AActor* RepresentativeInstance,
@@ -258,32 +263,24 @@ namespace PCGExActorCollectionInternal
 			return RepresentativeInstance;
 		}
 
-		if (!Entry.DeltaSourceLevel.ToSoftObjectPath().IsValid() || Entry.DeltaSourceActorName.IsNone())
+		if (!Entry.DeltaSourceActor.ToSoftObjectPath().IsValid())
 		{
 			return nullptr;
 		}
 
-		OutHandle = PCGExHelpers::LoadBlocking_AnyThread(Entry.DeltaSourceLevel.ToSoftObjectPath());
-		const UWorld* World = Entry.DeltaSourceLevel.Get();
-		if (!World || !World->PersistentLevel)
+		AActor* LevelActor = PCGExCollections::ResolveLevelActor(Entry.DeltaSourceActor.ToSoftObjectPath(), OutHandle);
+		if (!LevelActor)
 		{
 			return nullptr;
 		}
 
 		UClass* ExpectedClass = Entry.Actor.Get();
-		for (AActor* LevelActor : World->PersistentLevel->Actors)
+		if (ExpectedClass && !LevelActor->IsA(ExpectedClass))
 		{
-			if (!LevelActor || LevelActor->GetFName() != Entry.DeltaSourceActorName)
-			{
-				continue;
-			}
-			if (!ExpectedClass || LevelActor->IsA(ExpectedClass))
-			{
-				return LevelActor;
-			}
+			PCGExHelpers::SafeReleaseHandle(OutHandle);
+			return nullptr;
 		}
-
-		return nullptr;
+		return LevelActor;
 	}
 }
 

--- a/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
@@ -657,6 +657,11 @@ void UPCGExOmniCollection::EDITOR_OnPostStagingRebuild()
 		UPCGExActorCollection::RebuildActorPropertiesFromComponents(this, ActorGlobals.SchemaMergePolicy);
 	}
 
+	EDITOR_RunTypeStatesPostStaging();
+}
+
+void UPCGExOmniCollection::EDITOR_RunTypeStatesPostStaging()
+{
 	// Per-type setup safety net (entry-add paths ensure eagerly), then dispatch -- newly
 	// needed machinery (e.g. the first level-sourced PCGData entry) runs within the session.
 	EDITOR_EnsureTypeSetup();
@@ -665,6 +670,17 @@ void UPCGExOmniCollection::EDITOR_OnPostStagingRebuild()
 		if (State)
 		{
 			State->EDITOR_OnHostPostStagingRebuild(this);
+		}
+	}
+}
+
+void UPCGExOmniCollection::EDITOR_OnHostRelocated()
+{
+	for (const TObjectPtr<UPCGExCollectionTypeState>& State : TypeStates)
+	{
+		if (State)
+		{
+			State->EDITOR_OnHostRelocated(this);
 		}
 	}
 }

--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -1505,9 +1505,22 @@ void UPCGExPCGDataAssetCollection::PreSave(FObjectPreSaveContext ObjectSaveConte
 
 void UPCGExPCGDataAssetCollection::EDITOR_OnPostStagingRebuild()
 {
+	EDITOR_RunTypeStatesPostStaging();
+}
+
+void UPCGExPCGDataAssetCollection::EDITOR_RunTypeStatesPostStaging()
+{
 	if (MachineryState)
 	{
 		MachineryState->EDITOR_OnHostPostStagingRebuild(this);
+	}
+}
+
+void UPCGExPCGDataAssetCollection::EDITOR_OnHostRelocated()
+{
+	if (MachineryState)
+	{
+		MachineryState->EDITOR_OnHostRelocated(this);
 	}
 }
 
@@ -1759,6 +1772,26 @@ void UPCGExPCGDataTypeState::EDITOR_OnHostPostStagingRebuild(UPCGExAssetCollecti
 {
 	FPCGExPCGDataAssetMachinery State = MakeMachinery(Host);
 	UPCGExPCGDataAssetCollection::RebuildSharedCollectionsFor(State);
+}
+
+void UPCGExPCGDataTypeState::EDITOR_OnHostRelocated(UPCGExAssetCollection* Host)
+{
+	FPCGExPCGDataAssetMachinery State = MakeMachinery(Host);
+	if (!State.IsValid())
+	{
+		return;
+	}
+
+	for (FPCGExPCGDataAssetCollectionEntry* Entry : State.Entries)
+	{
+		if (Entry && Entry->ExportedDataAsset && Entry->ExportedDataAsset->IsIn(Host))
+		{
+			Entry->Staging.Path = FSoftObjectPath(Entry->ExportedDataAsset);
+		}
+	}
+
+	// Re-packs from the live shared / per-entry collections, wherever they now live.
+	UPCGExPCGDataAssetCollection::RebuildCollectionMapsFor(State);
 }
 
 void UPCGExPCGDataTypeState::AppendCookDependencyAssetPaths(const UPCGExAssetCollection* Host, TSet<FSoftObjectPath>& OutPaths) const

--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -33,6 +33,8 @@
 #include "Helpers/PCGExCollectionsHelpers.h"
 #include "Helpers/PCGExDefaultLevelDataExporter.h"
 #include "Helpers/PCGExLevelDataExporter.h"
+#include "Helpers/PCGExStreamingHelpers.h"
+#include "GameFramework/Actor.h"
 
 
 // Static-init type registration: TypeId=PCGDataAsset, parent=Base
@@ -67,21 +69,31 @@ namespace PCGExPCGDataAssetCollection
 
 bool FPCGExPCGDataAssetCollectionEntry::Validate(const UPCGExAssetCollection* ParentCollection)
 {
-	if (!bIsSubCollection)
+	if (!bIsSubCollection && ParentCollection->bDoNotIgnoreInvalidEntries)
 	{
-		if (Source == EPCGExDataAssetEntrySource::Level)
+		switch (Source)
 		{
-			if (!Level.ToSoftObjectPath().IsValid() && ParentCollection->bDoNotIgnoreInvalidEntries)
+		case EPCGExDataAssetEntrySource::DataAsset:
+			if (!DataAsset.ToSoftObjectPath().IsValid())
 			{
 				return false;
 			}
-		}
-		else
-		{
-			if (!DataAsset.ToSoftObjectPath().IsValid() && ParentCollection->bDoNotIgnoreInvalidEntries)
+			break;
+		case EPCGExDataAssetEntrySource::Level:
+			if (!Level.ToSoftObjectPath().IsValid())
 			{
 				return false;
 			}
+			break;
+		case EPCGExDataAssetEntrySource::Actor:
+			if (!SourceActor.ToSoftObjectPath().IsValid())
+			{
+				return false;
+			}
+			break;
+		default:
+			ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+			return false;
 		}
 	}
 
@@ -108,209 +120,170 @@ namespace PCGExPCGDataAssetCollectionInternal
 	}
 }
 
-// Loads the PCG data asset (or exports level data) and computes combined bounds.
+void FPCGExPCGDataAssetCollectionEntry::ResetEditorContributions()
+{
+#if WITH_EDITORONLY_DATA
+	EditorMeshContributions.Reset();
+	EditorMeshInheritedDefaults.Reset();
+	EditorLocalPicks.Reset();
+	EditorLevelContributions.Reset();
+	EditorLevelLocalPicks.Reset();
+#endif
+}
+
+void FPCGExPCGDataAssetCollectionEntry::ResetExport(const UPCGExAssetCollection* OwningCollection)
+{
+	// Own subobjects get the transient-rename so they stop serializing; a pointer to another
+	// package's private subobject (cross-asset copy) is only nulled -- it must never survive a save.
+	auto Discard = [OwningCollection](auto& Embedded)
+	{
+		if (!Embedded)
+		{
+			return;
+		}
+		if (Embedded->GetOuter() == OwningCollection)
+		{
+			Embedded->Rename(nullptr, GetTransientPackage(),
+			                 REN_DontCreateRedirectors | REN_NonTransactional);
+		}
+		Embedded = nullptr;
+	};
+	Discard(ExportedDataAsset);
+	Discard(EmbeddedActorCollection);
+
+	Staging.Bounds = FBox(ForceInit);
+	Staging.Path = FSoftObjectPath();
+	ResetEditorContributions();
+}
+
+// Shared by the Level and Actor sources once their world is loaded and transform-current.
 //
-// Level-sourced entries route through the 3-arg exporter API so EditorMeshContributions /
-// EditorLocalPicks + EditorLevelContributions / EditorLevelLocalPicks are captured directly
-// into the entry's UPROPERTY storage. Tag_EntryIdx hashes (Meshes + Levels pins) and the
-// CollectionMap pin are NOT written here -- those are produced by the parent collection's
-// CompactSharedMesh / CompactSharedLevel / RebuildCollectionMaps, which see every entry's
-// contributions and resolve final shared indices.
+// Routes through the 3-arg exporter API so EditorMeshContributions / EditorLocalPicks +
+// EditorLevelContributions / EditorLevelLocalPicks are captured directly into the entry's
+// UPROPERTY storage. Tag_EntryIdx hashes (Meshes + Levels pins) and the CollectionMap pin are
+// NOT written here -- those are produced by the parent collection's CompactSharedMesh /
+// CompactSharedLevel / RebuildCollectionMaps, which see every entry's contributions and
+// resolve final shared indices.
+bool FPCGExPCGDataAssetCollectionEntry::ExportFromSource(const UPCGExAssetCollection* OwningCollection, const FPCGExLevelExportSource& ExportSource)
+{
+	// Always recreate ExportedDataAsset fresh. Reusing + resetting TaggedData leaves orphaned
+	// UPCGBasePointData subobjects in the outer chain that still serialize into the .uasset,
+	// which causes save-time pointer traversal crashes after repeated rebuilds.
+	if (ExportedDataAsset)
+	{
+		ExportedDataAsset->Rename(nullptr, GetTransientPackage(),
+		                          REN_DontCreateRedirectors | REN_NonTransactional);
+	}
+	ExportedDataAsset = NewObject<UPCGDataAsset>(const_cast<UPCGExAssetCollection*>(OwningCollection));
+
+	// Exporter via the type-globals seam, else a transient default. Editor-only data:
+	// cooked builds always take the fallback.
+	UPCGExLevelDataExporter* Exporter = nullptr;
+#if WITH_EDITORONLY_DATA
+	if (OwningCollection)
+	{
+		FPCGExPCGDataAssetCollectionGlobals Globals;
+		if (OwningCollection->GetTypeGlobals(Globals))
+		{
+			Exporter = Globals.LevelExporter;
+		}
+	}
+#endif
+
+	TObjectPtr<UPCGExLevelDataExporter> FallbackExporter;
+	if (!Exporter)
+	{
+		const auto& Settings = PCGEX_COLLECTIONS_SETTINGS;
+		UClass* ExporterClass = Settings.DefaultLevelExporterClass
+			? Settings.DefaultLevelExporterClass.Get()
+			: UPCGExDefaultLevelDataExporter::StaticClass();
+#if PCGEX_ENGINE_VERSION < 507
+		FallbackExporter = NewObject<UPCGExLevelDataExporter>(GetTransientPackage(), ExporterClass);
+#else
+		FallbackExporter = NewObject<UPCGExLevelDataExporter>(GetTransientPackageAsObject(), ExporterClass);
+#endif
+
+		Exporter = FallbackExporter;
+	}
+
+	// Wire the export context to write directly into the entry's UPROPERTY storage --
+	// no copy at the API boundary. Only available in editor builds; shipping builds run
+	// the exporter without capturing contributions (the shared collections are already
+	// baked into the per-entry ExportedDataAsset hashes at cook time).
+	FPCGExLevelExportContext ExportContext;
+	// Reset the capture buffers so a failed export doesn't leave stale data from a prior
+	// rebuild contributing to CompactSharedMesh / CompactSharedLevel.
+	ResetEditorContributions();
+#if WITH_EDITORONLY_DATA
+	ExportContext.MeshContributions = &EditorMeshContributions;
+	ExportContext.MeshInheritedDefaults = &EditorMeshInheritedDefaults;
+	ExportContext.MeshLocalPicks = &EditorLocalPicks;
+	ExportContext.LevelContributions = &EditorLevelContributions;
+	ExportContext.LevelLocalPicks = &EditorLevelLocalPicks;
+#endif
+	// The previous actor collection is the exporter's working buffer -- its CollectionGUID
+	// and EntryIds are bound by external references (variants). Cold external sessions load
+	// the externalized asset back. The entry ref stays assigned during export so the object
+	// stays GC-reachable.
+	if (!EmbeddedActorCollection && !ExternalActorCollection.IsNull())
+	{
+		PCGExHelpers::LoadBlocking_AnyThreadTpl(ExternalActorCollection);
+		EmbeddedActorCollection = ExternalActorCollection.Get();
+	}
+	ExportContext.PreviousActorCollection = EmbeddedActorCollection;
+	ExportContext.ActorCollectionOut = &EmbeddedActorCollection;
+
+	const bool bSuccess = Exporter->ExportLevelData(ExportSource, ExportedDataAsset, ExportContext);
+
+	if (bSuccess)
+	{
+		Staging.Path = FSoftObjectPath(ExportedDataAsset);
+		Staging.Bounds = PCGExPCGDataAssetCollectionInternal::ComputeBoundsFromAsset(ExportedDataAsset);
+
+		// Same actor set and frame as the export: a socket provider inside a subtree is a
+		// socket of that subtree, expressed root-relative like every other point.
+		for (AActor* Actor : ExportSource.Actors)
+		{
+			if (IPCGExSocketProvider* Provider = Cast<IPCGExSocketProvider>(Actor))
+			{
+				FPCGExSocket& NewSocket = Staging.Sockets.Emplace_GetRef(
+					Provider->GetSocketName_Implementation(),
+					ExportSource.ToFrame(Provider->GetSocketTransform_Implementation()),
+					Provider->GetSocketTag_Implementation());
+				NewSocket.bManaged = true;
+			}
+		}
+	}
+	else
+	{
+		Staging.Path = FSoftObjectPath();
+		Staging.Bounds = FBox(ForceInit);
+
+		// Failed exports return before ActorCollectionOut is assigned; the previous
+		// collection's outer chain was just retired -- never serialize it.
+		EmbeddedActorCollection = nullptr;
+		ResetEditorContributions();
+	}
+
+	return bSuccess;
+}
+
+// Loads the PCG data asset, or exports a level / an actor subtree into an embedded one, and
+// computes combined bounds. See ExportFromSource for the export half.
 void FPCGExPCGDataAssetCollectionEntry::UpdateStaging(const UPCGExAssetCollection* OwningCollection, int32 InInternalIndex, bool bRecursive)
 {
-	ClearManagedSockets();
-
 	if (bIsSubCollection)
 	{
+		ClearManagedSockets();
 		FPCGExAssetCollectionEntry::UpdateStaging(OwningCollection, InInternalIndex, bRecursive);
 		return;
 	}
 
-	if (Source == EPCGExDataAssetEntrySource::Level)
+	switch (Source)
 	{
-		// Level export depends on machinery the host must run -- in hosts that don't,
-		// stage nothing and point at the composition path. Capability query so future
-		// host kinds (per-type processor seam) only change the helper.
-		if (!UPCGExPCGDataAssetCollection::HostSupportsDataAssetMachinery(OwningCollection))
-		{
-			UE_LOG(LogPCGEx, Warning,
-			       TEXT("Level-sourced PCGDataAsset entry ('%s') is hosted by a collection without the level-export machinery -- entry skipped. Author it in a PCGDataAsset collection and reference that collection as a subcollection entry instead."),
-			       *Level.ToSoftObjectPath().ToString());
-
-			// Discard any embedded export carried in via a cross-asset copy: foreign hosts
-			// never consume it, and a pointer to another asset's private subobject must not
-			// survive a save. Own subobjects get the transient-rename (mirrors the recreate
-			// path below); foreign-owned pointers are only nulled.
-			auto DiscardEmbedded = [OwningCollection](auto& Embedded)
-			{
-				if (!Embedded)
-				{
-					return;
-				}
-				if (Embedded->GetOuter() == OwningCollection)
-				{
-					Embedded->Rename(nullptr, GetTransientPackage(),
-					                 REN_DontCreateRedirectors | REN_NonTransactional);
-				}
-				Embedded = nullptr;
-			};
-			DiscardEmbedded(ExportedDataAsset);
-			DiscardEmbedded(EmbeddedActorCollection);
-
-			Staging.Bounds = FBox(ForceInit);
-			Staging.Path = FSoftObjectPath();
-#if WITH_EDITORONLY_DATA
-			EditorMeshContributions.Reset();
-			EditorMeshInheritedDefaults.Reset();
-			EditorLocalPicks.Reset();
-			EditorLevelContributions.Reset();
-			EditorLevelLocalPicks.Reset();
-#endif
-			FPCGExAssetCollectionEntry::UpdateStaging(OwningCollection, InInternalIndex, bRecursive);
-			return;
-		}
-
-		// Level source: load world, export to embedded data asset
-		TSharedPtr<FStreamableHandle> Handle = PCGExHelpers::LoadBlocking_AnyThread(Level.ToSoftObjectPath());
-		UWorld* LoadedWorld = Level.Get();
-
-		if (!LoadedWorld)
-		{
-			Staging.Bounds = FBox(ForceInit);
-			Staging.Path = FSoftObjectPath();
-#if WITH_EDITORONLY_DATA
-			EditorMeshContributions.Reset();
-			EditorMeshInheritedDefaults.Reset();
-			EditorLocalPicks.Reset();
-			EditorLevelContributions.Reset();
-			EditorLevelLocalPicks.Reset();
-#endif
-			PCGExHelpers::SafeReleaseHandle(Handle);
-			FPCGExAssetCollectionEntry::UpdateStaging(OwningCollection, InInternalIndex, bRecursive);
-			return;
-		}
-
-		// Asset-loaded worlds carry identity ComponentToWorld/Bounds until this runs -- the
-		// exporter, the bounds evaluators and the socket scan below all read live component state.
-		PCGExHelpers::EnsureWorldTransformsCurrent(LoadedWorld);
-
-		// Always recreate ExportedDataAsset fresh. Reusing + resetting TaggedData leaves orphaned
-		// UPCGBasePointData subobjects in the outer chain that still serialize into the .uasset,
-		// which causes save-time pointer traversal crashes after repeated rebuilds.
-		if (ExportedDataAsset)
-		{
-			ExportedDataAsset->Rename(nullptr, GetTransientPackage(),
-			                          REN_DontCreateRedirectors | REN_NonTransactional);
-		}
-		ExportedDataAsset = NewObject<UPCGDataAsset>(const_cast<UPCGExAssetCollection*>(OwningCollection));
-
-		// Exporter via the type-globals seam, else a transient default. Editor-only data:
-		// cooked builds always take the fallback.
-		UPCGExLevelDataExporter* Exporter = nullptr;
-#if WITH_EDITORONLY_DATA
-		if (OwningCollection)
-		{
-			FPCGExPCGDataAssetCollectionGlobals Globals;
-			if (OwningCollection->GetTypeGlobals(Globals))
-			{
-				Exporter = Globals.LevelExporter;
-			}
-		}
-#endif
-
-		TObjectPtr<UPCGExLevelDataExporter> FallbackExporter;
-		if (!Exporter)
-		{
-			const auto& Settings = PCGEX_COLLECTIONS_SETTINGS;
-			UClass* ExporterClass = Settings.DefaultLevelExporterClass
-				? Settings.DefaultLevelExporterClass.Get()
-				: UPCGExDefaultLevelDataExporter::StaticClass();
-#if PCGEX_ENGINE_VERSION < 507
-			FallbackExporter = NewObject<UPCGExLevelDataExporter>(GetTransientPackage(), ExporterClass);
-#else
-			FallbackExporter = NewObject<UPCGExLevelDataExporter>(GetTransientPackageAsObject(), ExporterClass);
-#endif
-
-			Exporter = FallbackExporter;
-		}
-
-		// Wire the export context to write directly into the entry's UPROPERTY storage --
-		// no copy at the API boundary. Only available in editor builds; shipping builds run
-		// the exporter without capturing contributions (the shared collections are already
-		// baked into the per-entry ExportedDataAsset hashes at cook time).
-		FPCGExLevelExportContext ExportContext;
-#if WITH_EDITORONLY_DATA
-		// Reset editor-only capture buffers so a failed export doesn't leave stale data
-		// from a prior rebuild contributing to CompactSharedMesh / CompactSharedLevel.
-		EditorMeshContributions.Reset();
-		EditorMeshInheritedDefaults.Reset();
-		EditorLocalPicks.Reset();
-		EditorLevelContributions.Reset();
-		EditorLevelLocalPicks.Reset();
-		ExportContext.MeshContributions = &EditorMeshContributions;
-		ExportContext.MeshInheritedDefaults = &EditorMeshInheritedDefaults;
-		ExportContext.MeshLocalPicks = &EditorLocalPicks;
-		ExportContext.LevelContributions = &EditorLevelContributions;
-		ExportContext.LevelLocalPicks = &EditorLevelLocalPicks;
-#endif
-		// The previous actor collection is the exporter's working buffer -- its CollectionGUID
-		// and EntryIds are bound by external references (variants). Cold external sessions load
-		// the externalized asset back. The entry ref stays assigned during export so the object
-		// stays GC-reachable.
-		if (!EmbeddedActorCollection && !ExternalActorCollection.IsNull())
-		{
-			PCGExHelpers::LoadBlocking_AnyThreadTpl(ExternalActorCollection);
-			EmbeddedActorCollection = ExternalActorCollection.Get();
-		}
-		ExportContext.PreviousActorCollection = EmbeddedActorCollection;
-		ExportContext.ActorCollectionOut = &EmbeddedActorCollection;
-
-		const bool bSuccess = Exporter->ExportLevelData(LoadedWorld, ExportedDataAsset, ExportContext);
-
-		if (bSuccess)
-		{
-			Staging.Path = FSoftObjectPath(ExportedDataAsset);
-			Staging.Bounds = PCGExPCGDataAssetCollectionInternal::ComputeBoundsFromAsset(ExportedDataAsset);
-
-			// Scan for socket actors after export so the world is in the same initialized
-			// state the exporter used -- transforms are reliable at this point.
-			if (LoadedWorld->PersistentLevel)
-			{
-				for (AActor* Actor : LoadedWorld->PersistentLevel->Actors)
-				{
-					if (IPCGExSocketProvider* Provider = Cast<IPCGExSocketProvider>(Actor))
-					{
-						FPCGExSocket& NewSocket = Staging.Sockets.Emplace_GetRef(
-							Provider->GetSocketName_Implementation(),
-							Provider->GetSocketTransform_Implementation(),
-							Provider->GetSocketTag_Implementation());
-						NewSocket.bManaged = true;
-					}
-				}
-			}
-		}
-		else
-		{
-			Staging.Path = FSoftObjectPath();
-			Staging.Bounds = FBox(ForceInit);
-
-			// Failed exports return before ActorCollectionOut is assigned; the previous
-			// collection's outer chain was just retired -- never serialize it.
-			EmbeddedActorCollection = nullptr;
-#if WITH_EDITORONLY_DATA
-			EditorMeshContributions.Reset();
-			EditorMeshInheritedDefaults.Reset();
-			EditorLocalPicks.Reset();
-			EditorLevelContributions.Reset();
-			EditorLevelLocalPicks.Reset();
-#endif
-		}
-
-		PCGExHelpers::SafeReleaseHandle(Handle);
-	}
-	else
+	case EPCGExDataAssetEntrySource::DataAsset:
 	{
-		// DataAsset source: existing behavior. No mesh/level contributions captured.
+		ClearManagedSockets();
 		Staging.Path = DataAsset.ToSoftObjectPath();
 		TSharedPtr<FStreamableHandle> Handle = PCGExHelpers::LoadBlocking_AnyThreadTpl(DataAsset);
 
@@ -323,17 +296,85 @@ void FPCGExPCGDataAssetCollectionEntry::UpdateStaging(const UPCGExAssetCollectio
 			Staging.Bounds = FBox(ForceInit);
 		}
 
-#if WITH_EDITORONLY_DATA
 		// DataAsset-sourced entries don't contribute to the shared collections -- clear any
-		// stale contributions left behind by a prior Source==Level rebuild.
-		EditorMeshContributions.Reset();
-		EditorMeshInheritedDefaults.Reset();
-		EditorLocalPicks.Reset();
-		EditorLevelContributions.Reset();
-		EditorLevelLocalPicks.Reset();
-#endif
+		// stale contributions left behind by a prior export-sourced rebuild.
+		ResetEditorContributions();
 
 		PCGExHelpers::SafeReleaseHandle(Handle);
+		break;
+	}
+	case EPCGExDataAssetEntrySource::Level:
+	case EPCGExDataAssetEntrySource::Actor:
+	{
+		const bool bActorSource = Source == EPCGExDataAssetEntrySource::Actor;
+		const FSoftObjectPath SourcePath = bActorSource ? SourceActor.ToSoftObjectPath() : Level.ToSoftObjectPath();
+
+		// Export depends on machinery the host must run -- in hosts that don't, stage nothing
+		// and point at the composition path. Capability query so future host kinds (per-type
+		// processor seam) only change the helper.
+		if (!UPCGExPCGDataAssetCollection::HostSupportsDataAssetMachinery(OwningCollection))
+		{
+			UE_LOG(LogPCGEx, Warning,
+			       TEXT("%s-sourced PCGDataAsset entry ('%s') is hosted by a collection without the level-export machinery -- entry skipped. Author it in a PCGDataAsset collection and reference that collection as a subcollection entry instead."),
+			       bActorSource ? TEXT("Actor") : TEXT("Level"), *SourcePath.ToString());
+			ClearManagedSockets();
+			ResetExport(OwningCollection);
+			break;
+		}
+
+		if (bActorSource)
+		{
+			TSharedPtr<FStreamableHandle> Handle;
+			FString Failure;
+			AActor* Root = PCGExCollections::ResolveLevelActor(SourcePath, Handle, &Failure);
+			if (!Root)
+			{
+				// An unreachable source keeps the last export, sockets included: the actor is usually
+				// unreachable only because its level is closed, and an empty module is worse than a
+				// stale one. A deleted actor is the author's to fix -- the warning names it.
+				UE_LOG(LogPCGEx, Warning,
+				       TEXT("Actor-sourced PCGDataAsset entry: %s -- %s."),
+				       *Failure, ExportedDataAsset ? TEXT("keeping the previous export") : TEXT("no previous export, entry stages nothing"));
+				if (ExportedDataAsset)
+				{
+					Staging.Path = FSoftObjectPath(ExportedDataAsset);
+				}
+				else
+				{
+					ClearManagedSockets();
+					ResetExport(OwningCollection);
+				}
+				break;
+			}
+
+			ClearManagedSockets();
+			ExportFromSource(OwningCollection, FPCGExLevelExportSource::FromActorSubtree(Root));
+			PCGExHelpers::SafeReleaseHandle(Handle);
+			break;
+		}
+
+		ClearManagedSockets();
+		TSharedPtr<FStreamableHandle> Handle = PCGExHelpers::LoadBlocking_AnyThread(SourcePath);
+		UWorld* LoadedWorld = Level.Get();
+		if (!LoadedWorld)
+		{
+			ResetExport(OwningCollection);
+			PCGExHelpers::SafeReleaseHandle(Handle);
+			break;
+		}
+
+		// Asset-loaded worlds carry identity ComponentToWorld/Bounds until this runs -- the
+		// exporter, the bounds evaluators and the socket scan all read live component state.
+		PCGExHelpers::EnsureWorldTransformsCurrent(LoadedWorld);
+		ExportFromSource(OwningCollection, FPCGExLevelExportSource::FromWorld(LoadedWorld));
+		PCGExHelpers::SafeReleaseHandle(Handle);
+		break;
+	}
+	default:
+		ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+		ClearManagedSockets();
+		ResetExport(OwningCollection);
+		break;
 	}
 
 	FPCGExAssetCollectionEntry::UpdateStaging(OwningCollection, InInternalIndex, bRecursive);
@@ -343,13 +384,20 @@ void FPCGExPCGDataAssetCollectionEntry::SetAssetPath(const FSoftObjectPath& InPa
 {
 	FPCGExAssetCollectionEntry::SetAssetPath(InPath);
 
-	if (Source == EPCGExDataAssetEntrySource::Level)
+	switch (Source)
 	{
-		Level = TSoftObjectPtr<UWorld>(InPath);
-	}
-	else
-	{
+	case EPCGExDataAssetEntrySource::DataAsset:
 		DataAsset = TSoftObjectPtr<UPCGDataAsset>(InPath);
+		break;
+	case EPCGExDataAssetEntrySource::Level:
+		Level = TSoftObjectPtr<UWorld>(InPath);
+		break;
+	case EPCGExDataAssetEntrySource::Actor:
+		SourceActor = TSoftObjectPtr<AActor>(InPath);
+		break;
+	default:
+		ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+		break;
 	}
 }
 
@@ -358,16 +406,12 @@ void FPCGExPCGDataAssetCollectionEntry::EDITOR_Sanitize()
 {
 	FPCGExAssetCollectionEntry::EDITOR_Sanitize();
 
-	// Clean up embedded data when not in Level mode
-	if (Source != EPCGExDataAssetEntrySource::Level)
+	// Only the export-backed sources carry an embedded asset.
+	if (Source != EPCGExDataAssetEntrySource::Level && Source != EPCGExDataAssetEntrySource::Actor)
 	{
 		ExportedDataAsset = nullptr;
 		EmbeddedActorCollection = nullptr;
-		EditorMeshContributions.Reset();
-		EditorMeshInheritedDefaults.Reset();
-		EditorLocalPicks.Reset();
-		EditorLevelContributions.Reset();
-		EditorLevelLocalPicks.Reset();
+		ResetEditorContributions();
 	}
 }
 
@@ -378,23 +422,29 @@ void FPCGExPCGDataAssetCollectionEntry::EDITOR_GetSourceAssetPaths(TSet<FSoftObj
 		return;
 	}
 
-	// Source refs trigger rebuild -- not Staging.Path, which for Source==Level points at
-	// an embedded ExportedDataAsset inside the collection's own package.
-	if (Source == EPCGExDataAssetEntrySource::Level)
+	// Source refs trigger rebuild -- not Staging.Path, which for the export-backed sources
+	// points at an embedded ExportedDataAsset inside the collection's own package. An actor
+	// path's package is its level's, so the package-name match fires on a level save; OFPA
+	// actor saves reach it through the editor module's outer-path remap.
+	FSoftObjectPath SourcePath;
+	switch (Source)
 	{
-		const FSoftObjectPath LevelPath = Level.ToSoftObjectPath();
-		if (LevelPath.IsValid())
-		{
-			OutPaths.Emplace(LevelPath);
-		}
+	case EPCGExDataAssetEntrySource::DataAsset:
+		SourcePath = DataAsset.ToSoftObjectPath();
+		break;
+	case EPCGExDataAssetEntrySource::Level:
+		SourcePath = Level.ToSoftObjectPath();
+		break;
+	case EPCGExDataAssetEntrySource::Actor:
+		SourcePath = SourceActor.ToSoftObjectPath();
+		break;
+	default:
+		ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+		break;
 	}
-	else
+	if (SourcePath.IsValid())
 	{
-		const FSoftObjectPath AssetPath = DataAsset.ToSoftObjectPath();
-		if (AssetPath.IsValid())
-		{
-			OutPaths.Emplace(AssetPath);
-		}
+		OutPaths.Emplace(SourcePath);
 	}
 }
 
@@ -405,14 +455,20 @@ FSoftObjectPath FPCGExPCGDataAssetCollectionEntry::EDITOR_GetThumbnailAssetPath(
 		return FPCGExAssetCollectionEntry::EDITOR_GetThumbnailAssetPath();
 	}
 
-	// Level-sourced entries stage an embedded ExportedDataAsset inside the collection
-	// package; show the user-facing source (the UWorld) instead.
-	if (Source == EPCGExDataAssetEntrySource::Level)
+	// Export-backed entries stage an embedded ExportedDataAsset inside the collection package;
+	// show the user-facing source instead -- the UWorld, or the actor's level (the closest asset).
+	switch (Source)
 	{
+	case EPCGExDataAssetEntrySource::DataAsset:
+		return DataAsset.ToSoftObjectPath();
+	case EPCGExDataAssetEntrySource::Level:
 		return Level.ToSoftObjectPath();
+	case EPCGExDataAssetEntrySource::Actor:
+		return SourceActor.ToSoftObjectPath().GetWithoutSubPath();
+	default:
+		ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+		return FSoftObjectPath();
 	}
-
-	return DataAsset.ToSoftObjectPath();
 }
 #endif
 

--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -455,8 +455,38 @@ FSoftObjectPath FPCGExPCGDataAssetCollectionEntry::EDITOR_GetThumbnailAssetPath(
 		return FPCGExAssetCollectionEntry::EDITOR_GetThumbnailAssetPath();
 	}
 
-	// Export-backed entries stage an embedded ExportedDataAsset inside the collection package;
-	// show the user-facing source instead -- the UWorld, or the actor's level (the closest asset).
+	// Export-backed entries draw their EXPORT: the data-asset thumbnail renderer shows the exported
+	// geometry, which is what the entry stands for. Live embedded object first, externalized asset
+	// next, the source as the fallback before any export exists.
+	switch (Source)
+	{
+	case EPCGExDataAssetEntrySource::DataAsset:
+		return DataAsset.ToSoftObjectPath();
+	case EPCGExDataAssetEntrySource::Level:
+	case EPCGExDataAssetEntrySource::Actor:
+		if (ExportedDataAsset)
+		{
+			return FSoftObjectPath(ExportedDataAsset);
+		}
+		if (!ExternalExportedDataAsset.IsNull())
+		{
+			return ExternalExportedDataAsset.ToSoftObjectPath();
+		}
+		return EDITOR_GetActivationAssetPath();
+	default:
+		ensureMsgf(false, TEXT("Unhandled EPCGExDataAssetEntrySource"));
+		return FSoftObjectPath();
+	}
+}
+
+FSoftObjectPath FPCGExPCGDataAssetCollectionEntry::EDITOR_GetActivationAssetPath() const
+{
+	if (bIsSubCollection)
+	{
+		return FPCGExAssetCollectionEntry::EDITOR_GetActivationAssetPath();
+	}
+
+	// Opening an export means opening what authored it: the level, or the actor's level.
 	switch (Source)
 	{
 	case EPCGExDataAssetEntrySource::DataAsset:

--- a/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
@@ -1321,6 +1321,24 @@ void UPCGExAssetCollection::PostLoad()
 {
 	Super::PostLoad();
 
+	// Per-entry migrations (see FPCGExAssetCollectionEntry::OnHostPostLoad).
+	{
+		bool bEntryRewritten = false;
+		ForEachEntry([this, &bEntryRewritten](FPCGExAssetCollectionEntry* Entry, int32 /*Index*/)
+		{
+			if (Entry && Entry->OnHostPostLoad(this))
+			{
+				bEntryRewritten = true;
+			}
+		});
+#if WITH_EDITOR
+		if (bEntryRewritten)
+		{
+			(void)MarkPackageDirty();
+		}
+#endif
+	}
+
 #if WITH_EDITORONLY_DATA
 	// Single-pipeline slot migration: the legacy StagingPipeline pointer becomes the first
 	// element of the composable StagingPipelines array. Runs once; subsequent loads no-op.

--- a/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
@@ -1202,6 +1202,18 @@ void UPCGExAssetCollection::BuildCache()
 
 #pragma endregion
 
+void UPCGExAssetCollection::PostRename(UObject* OldOuter, const FName OldName)
+{
+	Super::PostRename(OldOuter, OldName);
+
+#if WITH_EDITOR
+	if (GetOutermost() != GetTransientPackage())
+	{
+		EDITOR_OnHostRelocated();
+	}
+#endif
+}
+
 void UPCGExAssetCollection::PostDuplicate(bool bDuplicateForPIE)
 {
 	Super::PostDuplicate(bDuplicateForPIE);

--- a/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
@@ -707,6 +707,21 @@ namespace PCGExCollections
 		return true;
 	}
 
+	void FPickUnpacker::AddCollection(UPCGExAssetCollection* InCollection)
+	{
+		if (!InCollection)
+		{
+			return;
+		}
+		const uint32 Idx = InCollection->GetCollectionGUID();
+		if (CollectionMap.Contains(Idx))
+		{
+			return;
+		}
+		CollectionMap.Add(Idx, InCollection);
+		NumUniqueEntries += InCollection->GetValidEntryNum();
+	}
+
 	void FPickUnpacker::RegisterCollectionsTo(FPickPacker& InPacker) const
 	{
 		for (const TPair<uint32, UPCGExAssetCollection*>& Pair : CollectionMap)

--- a/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
@@ -14,6 +14,10 @@
 #include "Data/PCGPointData.h"
 #include "Details/PCGExSettingsDetails.h"
 #include "Engine/Level.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Helpers/PCGExActorHelpers.h"
+#include "Helpers/PCGExStreamingHelpers.h"
 #if WITH_EDITOR
 #include "Helpers/PCGDynamicTrackingHelpers.h"
 #endif
@@ -1219,3 +1223,54 @@ namespace PCGExCollections
 		}
 	}
 }
+
+#pragma region ResolveLevelActor
+
+namespace PCGExCollections
+{
+	AActor* ResolveLevelActor(const FSoftObjectPath& ActorPath, TSharedPtr<FStreamableHandle>& OutHandle, FString* OutFailure)
+	{
+		auto Fail = [OutFailure](FString&& Reason) -> AActor*
+		{
+			if (OutFailure)
+			{
+				*OutFailure = MoveTemp(Reason);
+			}
+			return nullptr;
+		};
+
+		if (!ActorPath.IsValid() || !ActorPath.IsSubobject())
+		{
+			return Fail(TEXT("not an actor path"));
+		}
+
+		AActor* Actor = Cast<AActor>(ActorPath.ResolveObject());
+
+		if (!Actor)
+		{
+#if WITH_EDITOR
+			// Asset-registry query, no load. Checked BEFORE loading: ULevel::PostLoad only pulls
+			// external actors into a cold world for non-partitioned levels, so a partitioned one
+			// would load fine and then contain nothing.
+			if (ULevel::GetIsLevelPartitionedFromPackage(ActorPath.GetLongPackageFName()))
+			{
+				return Fail(FString::Printf(TEXT("level '%s' is World Partition -- only an open partitioned level can be read"), *ActorPath.GetLongPackageName()));
+			}
+#endif
+
+			OutHandle = PCGExHelpers::LoadBlocking_AnyThread(ActorPath);
+			Actor = Cast<AActor>(ActorPath.ResolveObject());
+			if (!Actor)
+			{
+				PCGExHelpers::SafeReleaseHandle(OutHandle);
+				return Fail(FString::Printf(TEXT("actor '%s' not found (level missing, actor deleted or renamed)"), *ActorPath.ToString()));
+			}
+		}
+
+		// No-op on a live world; a cold one reads identity transforms until this runs.
+		PCGExHelpers::EnsureWorldTransformsCurrent(Actor->GetWorld());
+		return Actor;
+	}
+}
+
+#pragma endregion

--- a/Source/PCGExCollections/Private/Helpers/PCGExDefaultLevelDataExporter.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExDefaultLevelDataExporter.cpp
@@ -182,15 +182,18 @@ namespace PCGExDefaultLevelDataExporterInternal
 		}
 	}
 
+	// Bounds stay relative to the actor's own transform (frame-invariant); only the written
+	// transform moves into the source frame.
 	static void WriteActorTransformAndBounds(
 		AActor* Actor, int32 Index,
+		const FPCGExLevelExportSource& Source,
 		const UPCGExBoundsEvaluator* Evaluator,
 		TPCGValueRange<FTransform>& Transforms,
 		TPCGValueRange<FVector>& BoundsMin,
 		TPCGValueRange<FVector>& BoundsMax)
 	{
 		const FTransform ActorTransform = Actor->GetActorTransform();
-		Transforms[Index] = ActorTransform;
+		Transforms[Index] = Source.ToFrame(ActorTransform);
 
 		const FBox WorldBounds = Evaluator ? Evaluator->EvaluateActorBounds(Actor, nullptr, -1) : FBox(ForceInit);
 		WorldBoundsToLocal(WorldBounds, ActorTransform, BoundsMin[Index], BoundsMax[Index]);
@@ -429,6 +432,7 @@ namespace PCGExDefaultLevelDataExporterInternal
 	// belongs on per-entry descriptor data, not a coarse per-actor world AABB.
 	static void ExtractMeshPointsFromActor(
 		AActor* Actor,
+		const FPCGExLevelExportSource& Source,
 		bool bCaptureMaterialOverrides,
 		TArray<FMeshPoint>& OutPoints,
 		TMap<FMeshEntryKey, FMeshInfo>& InOutMeshInfoMap,
@@ -530,7 +534,9 @@ namespace PCGExDefaultLevelDataExporterInternal
 					Point.MaterialVariantIndex = VariantIdx;
 					Point.BoundsMin = MeshBounds.Min;
 					Point.BoundsMax = MeshBounds.Max;
-					ISMC->GetInstanceTransform(Idx, Point.Transform, /*bWorldSpace=*/true);
+					FTransform InstanceWorld;
+					ISMC->GetInstanceTransform(Idx, InstanceWorld, /*bWorldSpace=*/true);
+					Point.Transform = Source.ToFrame(InstanceWorld);
 				}
 			}
 			else
@@ -542,7 +548,7 @@ namespace PCGExDefaultLevelDataExporterInternal
 				Point.SourceComponent = SMC;
 				Point.SourceActor = Actor;
 				Point.MaterialVariantIndex = VariantIdx;
-				Point.Transform = SMC->GetComponentTransform();
+				Point.Transform = Source.ToFrame(SMC->GetComponentTransform());
 				Point.BoundsMin = MeshBounds.Min;
 				Point.BoundsMax = MeshBounds.Max;
 			}
@@ -696,12 +702,12 @@ namespace PCGExDefaultLevelDataExporterInternal
 bool UPCGExDefaultLevelDataExporter::ExportLevelData_Implementation(UWorld* World, UPCGDataAsset* OutAsset)
 {
 	FPCGExLevelExportContext EmptyContext;
-	return ExportLevelData(World, OutAsset, EmptyContext);
+	return ExportLevelData(FPCGExLevelExportSource::FromWorld(World), OutAsset, EmptyContext);
 }
 
-bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
+bool UPCGExDefaultLevelDataExporter::ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
 {
-	if (!World || !OutAsset)
+	if (!Source.IsValid() || !OutAsset)
 	{
 		return false;
 	}
@@ -713,12 +719,6 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsse
 	// UPCGExPCGDataAssetCollection::CompactSharedMesh / CompactSharedLevel /
 	// RebuildCollectionMaps. The 2-arg BP-facing path delegates here with an empty
 	// context; in that case the asset is produced without hashes (raw attributes only).
-
-	ULevel* PersistentLevel = World->PersistentLevel;
-	if (!PersistentLevel)
-	{
-		return false;
-	}
 
 	// Move any previous inner subobjects to the transient package so they get GC'd
 	// instead of being saved as orphan exports in the collection's .uasset. Otherwise,
@@ -738,9 +738,9 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsse
 
 	// Phase 1: Collect and classify qualifying actors
 	TArray<FClassifiedActor> ClassifiedActors;
-	for (AActor* Actor : PersistentLevel->Actors)
+	for (AActor* Actor : Source.Actors)
 	{
-		if (!UPCGExActorContentFilter::StaticPassesFilter(ContentFilter, Actor))
+		if (!Actor || !UPCGExActorContentFilter::StaticPassesFilter(ContentFilter, Actor))
 		{
 			continue;
 		}
@@ -890,7 +890,7 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsse
 
 	for (const FClassifiedActor& CA : MeshActors)
 	{
-		ExtractMeshPointsFromActor(CA.Actor, bCaptureMaterialOverrides, AllMeshPoints, MeshInfoMap, PropertySchemaCache);
+		ExtractMeshPointsFromActor(CA.Actor, Source, bCaptureMaterialOverrides, AllMeshPoints, MeshInfoMap, PropertySchemaCache);
 	}
 
 	// Create mesh point data
@@ -994,7 +994,7 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsse
 
 		for (int32 i = 0; i < ActorActors.Num(); i++)
 		{
-			WriteActorTransformAndBounds(ActorActors[i].Actor, i, BoundsEvaluator, Transforms, BMin, BMax);
+			WriteActorTransformAndBounds(ActorActors[i].Actor, i, Source, BoundsEvaluator, Transforms, BMin, BMax);
 		}
 
 		InitMetadata(ActorPointData, ActorActors.Num());
@@ -1111,7 +1111,7 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(UWorld* World, UPCGDataAsse
 
 		for (int32 i = 0; i < LevelActors.Num(); i++)
 		{
-			WriteActorTransformAndBounds(LevelActors[i].Actor, i, BoundsEvaluator, Transforms, BMin, BMax);
+			WriteActorTransformAndBounds(LevelActors[i].Actor, i, Source, BoundsEvaluator, Transforms, BMin, BMax);
 		}
 
 		InitMetadata(LevelPointData, LevelActors.Num());

--- a/Source/PCGExCollections/Private/Helpers/PCGExLevelDataExporter.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExLevelDataExporter.cpp
@@ -2,3 +2,72 @@
 // Released under the MIT license https://opensource.org/license/MIT/
 
 #include "Helpers/PCGExLevelDataExporter.h"
+
+#include "PCGExAssemblyRoot.h"
+#include "Engine/Level.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+#pragma region FPCGExLevelExportSource
+
+FPCGExLevelExportSource FPCGExLevelExportSource::FromWorld(UWorld* InWorld)
+{
+	FPCGExLevelExportSource Source;
+	Source.World = InWorld;
+	if (InWorld && InWorld->PersistentLevel)
+	{
+		Source.Actors.Reserve(InWorld->PersistentLevel->Actors.Num());
+		for (AActor* Actor : InWorld->PersistentLevel->Actors)
+		{
+			if (Actor)
+			{
+				Source.Actors.Add(Actor);
+			}
+		}
+	}
+	return Source;
+}
+
+FPCGExLevelExportSource FPCGExLevelExportSource::FromActorSubtree(AActor* InRoot)
+{
+	FPCGExLevelExportSource Source;
+	if (!InRoot)
+	{
+		return Source;
+	}
+
+	Source.World = InRoot->GetWorld();
+	Source.Root = InRoot;
+
+	const IPCGExAssemblyRoot* AssemblyRoot = Cast<IPCGExAssemblyRoot>(InRoot);
+	Source.Frame = AssemblyRoot ? AssemblyRoot->GetAssemblyFrame() : InRoot->GetActorTransform();
+
+	// Depth-first over attach children. A pruned node takes its whole subtree with it; a node the
+	// root keeps is content even when it is a bare grouping pivot -- the exporter's own content
+	// filter decides what becomes a point.
+	TArray<AActor*> Stack;
+	Stack.Add(InRoot);
+
+	TArray<AActor*> Children;
+	while (!Stack.IsEmpty())
+	{
+		const AActor* Node = Stack.Pop(EAllowShrinking::No);
+
+		Children.Reset();
+		Node->GetAttachedActors(Children, /*bResetArray=*/true, /*bRecursivelyIncludeAttachedActors=*/false);
+
+		for (AActor* Child : Children)
+		{
+			if (!Child || (AssemblyRoot && !AssemblyRoot->IsAssemblyContent(Child)))
+			{
+				continue;
+			}
+			Source.Actors.Add(Child);
+			Stack.Add(Child);
+		}
+	}
+
+	return Source;
+}
+
+#pragma endregion

--- a/Source/PCGExCollections/Private/PCGExAssemblyRoot.cpp
+++ b/Source/PCGExCollections/Private/PCGExAssemblyRoot.cpp
@@ -1,0 +1,12 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "PCGExAssemblyRoot.h"
+
+#include "GameFramework/Actor.h"
+
+FTransform IPCGExAssemblyRoot::GetAssemblyFrame() const
+{
+	const AActor* Self = Cast<AActor>(this);
+	return Self ? Self->GetActorTransform() : FTransform::Identity;
+}

--- a/Source/PCGExCollections/Private/PCGExAssemblyRootActor.cpp
+++ b/Source/PCGExCollections/Private/PCGExAssemblyRootActor.cpp
@@ -1,0 +1,30 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "PCGExAssemblyRootActor.h"
+
+#include "Components/BillboardComponent.h"
+#include "Components/SceneComponent.h"
+
+APCGExAssemblyRootActor::APCGExAssemblyRootActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	USceneComponent* Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
+	Root->SetMobility(EComponentMobility::Static);
+	RootComponent = Root;
+
+	// Its own components never render or collide; the attached content does. Deliberately NOT an
+	// editor-only actor: the scanners that consume it reject editor-only actors.
+	SetActorHiddenInGame(true);
+	SetActorEnableCollision(false);
+
+#if WITH_EDITORONLY_DATA
+	Sprite = CreateEditorOnlyDefaultSubobject<UBillboardComponent>(TEXT("Sprite"));
+	if (Sprite)
+	{
+		Sprite->SetupAttachment(Root);
+		Sprite->bIsScreenSizeScaled = true;
+	}
+#endif
+}

--- a/Source/PCGExCollections/Public/Collections/PCGExActorCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExActorCollection.h
@@ -79,20 +79,24 @@ struct PCGEXCOLLECTIONS_API FPCGExActorCollectionEntry : public FPCGExAssetColle
 	UPROPERTY()
 	TArray<FSoftObjectPath> DeltaCollateralPaths;
 
-	/** Optional: reference a specific level to capture property deltas from a placed actor.
-	 *  The actor's class must match the Actor class ref. During UpdateStaging,
-	 *  the property delta is computed from that instance vs its CDO. */
+	/** Optional: a placed actor to capture the property delta from (its class must match Actor). During
+	 *  UpdateStaging the delta is computed from that instance vs its CDO. Its level must not be World
+	 *  Partition: a closed partitioned level cannot be read. */
 	UPROPERTY(EditAnywhere, Category = "Settings|Delta", meta=(EditCondition="!bIsSubCollection", EditConditionHides))
-	TSoftObjectPtr<UWorld> DeltaSourceLevel;
+	TSoftObjectPtr<AActor> DeltaSourceActor;
 
-	/** Name of the actor within the level to capture delta from. */
-	UPROPERTY(EditAnywhere, Category = "Settings|Delta", meta=(EditCondition="!bIsSubCollection ", EditConditionHides))
-	FName DeltaSourceActorName;
+	/** LEGACY delta-source pair (level + actor name). Folded into DeltaSourceActor by OnHostPostLoad. */
+	UPROPERTY()
+	TSoftObjectPtr<UWorld> DeltaSourceLevel_DEPRECATED;
+
+	UPROPERTY()
+	FName DeltaSourceActorName_DEPRECATED;
 
 	// Lifecycle
 	virtual bool Validate(const UPCGExAssetCollection* ParentCollection) override;
 	virtual void UpdateStaging(const UPCGExAssetCollection* OwningCollection, int32 InInternalIndex, bool bRecursive) override;
 	virtual void SetAssetPath(const FSoftObjectPath& InPath) override;
+	virtual bool OnHostPostLoad(UPCGExAssetCollection* Host) override;
 
 #if WITH_EDITOR
 	virtual void EDITOR_Sanitize() override;
@@ -150,7 +154,7 @@ public:
 	 * Source resolution per entry:
 	 *   1. If RepresentativeInstances is non-empty and its slot at the entry's index is
 	 *      non-null, that live actor is the donor. (Level-exporter path: instance in-hand.)
-	 *   2. Else, if entry.DeltaSourceLevel + DeltaSourceActorName resolves to a placed actor
+	 *   2. Else, if entry.DeltaSourceActor resolves to a placed actor
 	 *      whose class matches entry.Actor, that actor is the donor. (Standalone authored
 	 *      path: user pointed the entry at a level-placed actor.)
 	 *   3. Else, the entry contributes no schema and gets no overrides (its row in the merged
@@ -165,7 +169,7 @@ public:
 	 *
 	 * @param Policy            Conflict resolution policy. Defaults to StrictTypeMatch.
 	 * @param RepresentativeInstances Parallel to Entries; entries with null/missing slots fall
-	 *                          through to DeltaSourceLevel resolution. May be empty.
+	 *                          through to DeltaSourceActor resolution. May be empty.
 	 */
 	void RebuildPropertiesFromActorComponents(
 		EPCGExSchemaMergePolicy Policy = EPCGExSchemaMergePolicy::StrictTypeMatch,

--- a/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
@@ -142,6 +142,8 @@ public:
 	 *  over actor-typed entries (matching a native actor collection), then dispatches the
 	 *  post-rebuild hook into every type state. */
 	virtual void EDITOR_OnPostStagingRebuild() override;
+	virtual void EDITOR_RunTypeStatesPostStaging() override;
+	virtual void EDITOR_OnHostRelocated() override;
 
 	/** IPCGExExternalPackageProducer via every type state. */
 	virtual void EDITOR_GetExternalPackages(TSet<UPackage*>& OutPackages) const override;

--- a/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
@@ -180,6 +180,7 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	virtual void EDITOR_Sanitize() override;
 	virtual void EDITOR_GetSourceAssetPaths(TSet<FSoftObjectPath>& OutPaths) const override;
 	virtual FSoftObjectPath EDITOR_GetThumbnailAssetPath() const override;
+	virtual FSoftObjectPath EDITOR_GetActivationAssetPath() const override;
 #endif
 
 private:

--- a/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
@@ -325,6 +325,10 @@ public:
 	virtual void OnHostSerializeSave_End(UPCGExAssetCollection* Host) override;
 #if WITH_EDITOR
 	virtual void EDITOR_OnHostPostStagingRebuild(UPCGExAssetCollection* Host) override;
+
+	/** Embedded exports moved with the host; their Staging.Path strings and the CollectionMap rows baked
+	 *  inside them did not. Re-stamps both from the live objects. */
+	virtual void EDITOR_OnHostRelocated(UPCGExAssetCollection* Host) override;
 	virtual void AppendCookDependencyAssetPaths(const UPCGExAssetCollection* Host, TSet<FSoftObjectPath>& OutPaths) const override;
 	virtual void EDITOR_AppendExternalPackages(const UPCGExAssetCollection* Host, TSet<UPackage*>& OutPackages) const override;
 
@@ -530,6 +534,8 @@ public:
 
 #if WITH_EDITOR
 	virtual void EDITOR_OnPostStagingRebuild() override;
+	virtual void EDITOR_RunTypeStatesPostStaging() override;
+	virtual void EDITOR_OnHostRelocated() override;
 	virtual void EDITOR_AddBrowserSelectionInternal(const TArray<FAssetData>& InAssetData) override;
 
 	/** IPCGExExternalPackageProducer via the owned machinery state. */

--- a/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
@@ -13,8 +13,10 @@
 
 #include "PCGExPCGDataAssetCollection.generated.h"
 
+class AActor;
 class UPCGDataAsset;
 class UPCGExPCGDataAssetCollection;
+struct FPCGExLevelExportSource;
 class UPCGExLevelDataExporter;
 class UPCGExMeshCollection;
 class UPCGExActorCollection;
@@ -27,6 +29,7 @@ enum class EPCGExDataAssetEntrySource : uint8
 {
 	DataAsset = 0 UMETA(DisplayName = "Data Asset", ToolTip="Reference an existing PCGDataAsset", ActionIcon="PCGDA_DataAsset"),
 	Level     = 1 UMETA(DisplayName = "Level", ToolTip="Export a level to an embedded PCGDataAsset", ActionIcon="PCGDA_Level"),
+	Actor     = 2 UMETA(DisplayName = "Actor", ToolTip="Export an actor's attached subtree, as if it were a level, to an embedded PCGDataAsset. Points are relative to the actor.", ActionIcon="PCGDA_Level"),
 };
 
 /**
@@ -86,7 +89,13 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	UPROPERTY(EditAnywhere, Category = Settings, meta=(EditCondition="Source == EPCGExDataAssetEntrySource::Level && !bIsSubCollection", EditConditionHides))
 	TSoftObjectPtr<UWorld> Level;
 
-	/** Only in Level mode: a DataAsset-sourced entry references a finished asset with no level behind it. */
+	/** Root actor whose attached subtree is exported (used when Source == Actor). Its level must not be
+	 *  World Partition: a closed partitioned level cannot be read. */
+	UPROPERTY(EditAnywhere, Category = Settings, meta=(EditCondition="Source == EPCGExDataAssetEntrySource::Actor && !bIsSubCollection", EditConditionHides))
+	TSoftObjectPtr<AActor> SourceActor;
+
+	/** Only in Level mode. An Actor-sourced entry answers null on purpose: its host level is a container,
+	 *  not a level whose content the entry stands for. A DataAsset-sourced entry has no level at all. */
 	virtual FSoftObjectPath GetSourceLevelPath() const override
 	{
 		return (!bIsSubCollection && Source == EPCGExDataAssetEntrySource::Level)
@@ -172,6 +181,17 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	virtual void EDITOR_GetSourceAssetPaths(TSet<FSoftObjectPath>& OutPaths) const override;
 	virtual FSoftObjectPath EDITOR_GetThumbnailAssetPath() const override;
 #endif
+
+private:
+	/** Level and Actor sources share everything past the load: export into a fresh embedded asset,
+	 *  capture contributions, scan sockets. Returns false when the export produced nothing. */
+	bool ExportFromSource(const UPCGExAssetCollection* OwningCollection, const FPCGExLevelExportSource& ExportSource);
+
+	/** Editor-only capture buffers -- every reset site in UpdateStaging goes through here. */
+	void ResetEditorContributions();
+
+	/** Staging + embedded export back to "nothing" -- a failed or impossible export. */
+	void ResetExport(const UPCGExAssetCollection* OwningCollection);
 };
 
 /** Concrete collection for UPCGDataAsset references with optional level-sourced entries.

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -451,6 +451,14 @@ struct PCGEXCOLLECTIONS_API FPCGExAssetCollectionEntry
 	 * exported data asset rather than the authored UWorld.
 	 */
 	virtual FSoftObjectPath EDITOR_GetThumbnailAssetPath() const;
+
+	/** Editor-only: what a double-click on the entry opens. Defaults to the thumbnail asset; override
+	 *  when the picture and the thing to edit differ (an export drawn from its data asset, opened at
+	 *  its source level). */
+	virtual FSoftObjectPath EDITOR_GetActivationAssetPath() const
+	{
+		return EDITOR_GetThumbnailAssetPath();
+	}
 #endif
 
 

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -1021,6 +1021,17 @@ public:
 	virtual void PostLoad() override;
 	virtual void BeginDestroy() override;
 
+	/** Rename / re-outer of THIS object (UObject::Rename, not a content-browser asset rename, which fixes
+	 *  soft paths itself). Dispatches EDITOR_OnHostRelocated unless the move is a retirement to transient. */
+	virtual void PostRename(UObject* OldOuter, const FName OldName) override;
+
+#if WITH_EDITOR
+	/** Hosts with machinery that bakes host-relative paths dispatch into their type states here. */
+	virtual void EDITOR_OnHostRelocated()
+	{
+	}
+#endif
+
 	/**
 	 * Re-stage every entry (SyncEntryIds -> per-entry UpdateStaging/PostUpdateStaging ->
 	 * cache invalidation). Entries whose Staging.bAuthored is set keep their staging content
@@ -1147,6 +1158,18 @@ public:
 	 * calling EDITOR_RebuildEntryStaging per stale index) and fires once at the batch end.
 	 */
 	virtual void EDITOR_OnPostStagingRebuild()
+	{
+	}
+
+	/**
+	 * The per-type machinery that must follow a re-stage: PCGData shared-collection compaction, entry
+	 * hash rewrite, CollectionMap bake. Hosts with type states override it; EDITOR_OnPostStagingRebuild
+	 * runs it for the editor rebuild paths. A caller of the raw RebuildStagingData owns calling it --
+	 * without it, freshly exported assets carry raw attributes and no CollectionMap pin, and every
+	 * downstream Map consumer fails with nothing else to say (the unpacker skips an attribute-less
+	 * dataset silently).
+	 */
+	virtual void EDITOR_RunTypeStatesPostStaging()
 	{
 	}
 

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -420,6 +420,17 @@ struct PCGEXCOLLECTIONS_API FPCGExAssetCollectionEntry
 	virtual void SetAssetPath(const FSoftObjectPath& InPath);
 	virtual void GetAssetPaths(TSet<FSoftObjectPath>& OutPaths) const;
 
+	/**
+	 * Host-side load hook, one call per entry from UPCGExAssetCollection::PostLoad. Entries are structs and
+	 * get no PostLoad of their own, so per-entry data migration (deprecated slots folded into their
+	 * successors) lives here. Runs in every build: cooked data saved before a migration still carries the
+	 * old slots. Return true when something was rewritten so the host can dirty its package.
+	 */
+	virtual bool OnHostPostLoad(UPCGExAssetCollection* Host)
+	{
+		return false;
+	}
+
 #if WITH_EDITOR
 	virtual void EDITOR_Sanitize();
 

--- a/Source/PCGExCollections/Public/Core/PCGExCollectionTypeState.h
+++ b/Source/PCGExCollections/Public/Core/PCGExCollectionTypeState.h
@@ -65,6 +65,12 @@ public:
 	{
 	}
 
+	/** The host was renamed or re-outered (externalized, internalized, moved). Paths baked as strings
+	 *  under the host -- an embedded export's Staging.Path, CollectionMap rows -- did not move with it. */
+	virtual void EDITOR_OnHostRelocated(UPCGExAssetCollection* Host)
+	{
+	}
+
 	virtual void AppendCookDependencyAssetPaths(const UPCGExAssetCollection* Host, TSet<FSoftObjectPath>& OutPaths) const
 	{
 	}

--- a/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
@@ -24,8 +24,10 @@ namespace PCGExDetails
 }
 
 struct FPCGContext;
+struct FStreamableHandle;
 struct FPCGMeshInstanceList;
 struct FPCGSkinnedMeshInstanceList;
+class AActor;
 class UPCGBasePointData;
 class UPCGExSelectorFactoryData;
 class UPCGManagedActors;
@@ -37,6 +39,21 @@ class FPCGExPickerScratchBase;
 namespace PCGExCollections
 {
 	class FSelectorSharedDataCache;
+
+	/**
+	 * Resolve an actor placed in a level from its soft path, for authoring-time reads (delta capture,
+	 * actor-rooted exports). A live actor wins; otherwise the LEVEL package is soft-loaded (an actor's
+	 * package name is always its map's, OFPA included) and the sub-path resolved into it. Partitioned
+	 * levels are refused outright: a cold-loaded one carries no actors. The returned world has had
+	 * PCGExHelpers::EnsureWorldTransformsCurrent run over it -- component transforms are readable.
+	 *
+	 * OutHandle keeps the cold world alive; release it as soon as the read is done and never cache it
+	 * (a resident, referenced world makes a later map open fail its unload).
+	 */
+	PCGEXCOLLECTIONS_API AActor* ResolveLevelActor(
+		const FSoftObjectPath& ActorPath,
+		TSharedPtr<FStreamableHandle>& OutHandle,
+		FString* OutFailure = nullptr);
 }
 
 namespace PCGExMeshCollection

--- a/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
@@ -573,6 +573,10 @@ namespace PCGExCollections
 		 */
 		void RegisterCollectionsTo(FPickPacker& InPacker) const;
 
+		/** Register one already-loaded collection under its GUID. For readers with no PCG context to hand
+		 *  UnpackDataset (editor tooling, thumbnails); hashes then resolve exactly as after an unpack. */
+		void AddCollection(UPCGExAssetCollection* InCollection);
+
 		/** Unpack collection mappings from an attribute set */
 		bool UnpackDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet);
 

--- a/Source/PCGExCollections/Public/Helpers/PCGExDefaultLevelDataExporter.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExDefaultLevelDataExporter.h
@@ -44,7 +44,7 @@ enum class EPCGExActorExportType : uint8
 /**
  * Default level data exporter that replicates the engine's UPCGLevelToAsset behavior.
  *
- * For each qualifying actor in the level:
+ * For each qualifying actor of the export source (a whole level, or one actor's subtree):
  * - Classifies actors as Mesh or Actor (or Skip)
  * - Creates a point at the actor's transform
  * - Stores mesh/actor references, materials, and bounds as metadata attributes
@@ -117,7 +117,7 @@ public:
 	FName InstanceTagsAttributeName = FName("InstanceTags");
 
 	virtual bool ExportLevelData_Implementation(UWorld* World, UPCGDataAsset* OutAsset) override;
-	virtual bool ExportLevelData(UWorld* World, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext) override;
+	virtual bool ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext) override;
 
 	/** Classify an actor. Override for custom logic.
 	 *  Default behaviour:

--- a/Source/PCGExCollections/Public/Helpers/PCGExLevelDataExporter.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExLevelDataExporter.h
@@ -9,10 +9,51 @@
 
 #include "PCGExLevelDataExporter.generated.h"
 
+class AActor;
 class UPCGDataAsset;
 class UPCGExActorCollection;
+class UWorld;
 struct FPCGExMeshCollectionEntry;
 struct FPCGExLevelCollectionEntry;
+
+/**
+ * What a level export reads: a world, the actors to consider, and the frame the output is expressed
+ * in. Two shapes -- a whole persistent level (identity frame, today's behaviour) or one actor's
+ * attached subtree exported as if it were a level (frame = the root's transform, root excluded).
+ * The exporter still runs its content filter over Actors; the source only decides candidacy.
+ */
+struct PCGEXCOLLECTIONS_API FPCGExLevelExportSource
+{
+	UWorld* World = nullptr;
+
+	/** Null for a whole-level source. Never exported itself. */
+	AActor* Root = nullptr;
+
+	/** Every written transform is expressed relative to this. */
+	FTransform Frame = FTransform::Identity;
+
+	TArray<AActor*> Actors;
+
+	bool IsValid() const
+	{
+		return World != nullptr;
+	}
+
+	/** Every actor of the persistent level, identity frame. */
+	static FPCGExLevelExportSource FromWorld(UWorld* InWorld);
+
+	/**
+	 * Root's attached descendants, recursively, frame = root's actor transform. When Root implements
+	 * IPCGExAssemblyRoot its prune predicate bounds the descent and its frame is used instead.
+	 */
+	static FPCGExLevelExportSource FromActorSubtree(AActor* InRoot);
+
+	/** World-space to frame-relative. Identity frame returns the input unchanged. */
+	FTransform ToFrame(const FTransform& WorldTransform) const
+	{
+		return Frame.Equals(FTransform::Identity) ? WorldTransform : WorldTransform.GetRelativeTransform(Frame);
+	}
+};
 
 /**
  * Output state populated by UPCGExLevelDataExporter::ExportLevelData (rich C++ overload).
@@ -88,13 +129,14 @@ struct PCGEXCOLLECTIONS_API FPCGExLevelExportContext
  *    Custom BP subclasses override _Implementation. No contribution capture; the
  *    resulting asset carries raw attributes (Mesh / ActorClass / LevelAsset) and no
  *    Tag_EntryIdx / CollectionMap. Standalone use only.
- *  - C++ virtual ExportLevelData(World, OutAsset, FPCGExLevelExportContext&):
+ *  - C++ virtual ExportLevelData(Source, OutAsset, FPCGExLevelExportContext&):
  *    used by UPCGExPCGDataAssetCollection to capture editor-only mesh + level
  *    contributions that feed shared-collection compaction (CompactSharedMesh /
  *    CompactSharedLevel). The exporter never builds inline embedded collections,
  *    never writes Tag_EntryIdx, and never emplaces the CollectionMap pin --
  *    those responsibilities live on the caller. Default impl on the base forwards
- *    to the BP-facing path.
+ *    to the BP-facing path with the source's world -- a BP exporter always sees the
+ *    whole level, never a subtree.
  */
 UCLASS(Abstract, Blueprintable, BlueprintType, EditInlineNew, DefaultToInstanced, meta=(DisplayName="Level Data Exporter", PCGExNodeLibraryDoc="staging/collections/pcg-data-asset-collection/level-data-exporter"))
 class PCGEXCOLLECTIONS_API UPCGExLevelDataExporter : public UObject
@@ -121,14 +163,15 @@ public:
 	/**
 	 * Rich C++-only export entry point. Populates an FPCGExLevelExportContext with
 	 * mesh-entry contributions and per-mesh-point packed local picks for the consumer
-	 * to merge across sibling entries.
+	 * to merge across sibling entries. Every transform written must go through
+	 * Source.ToFrame -- a subtree source is only a level when its output is root-relative.
 	 *
 	 * Default implementation forwards to the BP-facing ExportLevelData; mesh
 	 * contributions are not captured in that path. Override in C++ subclasses
 	 * (see UPCGExDefaultLevelDataExporter) to populate the context.
 	 */
-	virtual bool ExportLevelData(UWorld* World, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
+	virtual bool ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
 	{
-		return ExportLevelData(World, OutAsset);
+		return ExportLevelData(Source.World, OutAsset);
 	}
 };

--- a/Source/PCGExCollections/Public/PCGExAssemblyRoot.h
+++ b/Source/PCGExCollections/Public/PCGExAssemblyRoot.h
@@ -1,0 +1,38 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+
+#include "PCGExAssemblyRoot.generated.h"
+
+class AActor;
+
+UINTERFACE(MinimalAPI)
+class UPCGExAssemblyRoot : public UInterface
+{
+	GENERATED_BODY()
+};
+
+/**
+ * An actor that can be exported as if it were a level: its attached subtree is the content, its
+ * transform is the frame. Implement to bound the descent (owned actors, nested containers, ignored
+ * subtrees...) -- a root without the interface exports every attached descendant.
+ * Consumed by FPCGExLevelExportSource::FromActorSubtree.
+ */
+class PCGEXCOLLECTIONS_API IPCGExAssemblyRoot
+{
+	GENERATED_BODY()
+
+public:
+	/** False prunes Node AND everything attached below it. Null is never content. */
+	virtual bool IsAssemblyContent(const AActor* Node) const
+	{
+		return Node != nullptr;
+	}
+
+	/** Frame the exported points are expressed in. Default: the implementing actor's transform. */
+	virtual FTransform GetAssemblyFrame() const;
+};

--- a/Source/PCGExCollections/Public/PCGExAssemblyRootActor.h
+++ b/Source/PCGExCollections/Public/PCGExAssemblyRootActor.h
@@ -1,0 +1,31 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "PCGExAssemblyRoot.h"
+
+#include "PCGExAssemblyRootActor.generated.h"
+
+class UBillboardComponent;
+
+/**
+ * Barebone assembly root: whatever is attached under it is exported as if it were a level, relative to
+ * this actor. Point a PCGDataAsset collection entry (Source == Actor) at it, or drop it inside a
+ * Valency cage, which registers it as one DataAsset module. Authors nothing itself and spawns nothing.
+ */
+UCLASS(BlueprintType, Blueprintable, DisplayName = "[PCGEx] Assembly Root", meta=(PCGExNodeLibraryDoc="staging/collections/pcg-data-asset-collection/assembly-root"))
+class PCGEXCOLLECTIONS_API APCGExAssemblyRootActor : public AActor, public IPCGExAssemblyRoot
+{
+	GENERATED_BODY()
+
+public:
+	APCGExAssemblyRootActor();
+
+#if WITH_EDITORONLY_DATA
+	UPROPERTY()
+	TObjectPtr<UBillboardComponent> Sprite;
+#endif
+};

--- a/Source/PCGExCollectionsEditor/PCGExCollectionsEditor.Build.cs
+++ b/Source/PCGExCollectionsEditor/PCGExCollectionsEditor.Build.cs
@@ -56,6 +56,7 @@ public class PCGExCollectionsEditor : ModuleRules
 			{
 				"ContentBrowser",
 				"InputCore",
+				"RenderCore",
 				"AssetTools",
 				"AssetRegistry",
 				"Slate",

--- a/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExActorCollectionEditor.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExActorCollectionEditor.cpp
@@ -14,20 +14,19 @@
 #include "Collections/PCGExActorCollection.h"
 #include "GameFramework/Actor.h"
 #include "Misc/PackageName.h"
+#include "UObject/Package.h"
 
 namespace PCGExActorCollectionEditor
 {
 	void AddOrUpdateActorEntry(UPCGExActorCollection* Collection, AActor* Actor)
 	{
 		TSoftClassPtr<AActor> ActorClass(Actor->GetClass());
-		FSoftObjectPath WorldPath(Actor->GetWorld());
-		FName ActorFName = Actor->GetFName();
+		const TSoftObjectPtr<AActor> ActorRef(Actor);
 
 		FPCGExActorCollectionEntry* Existing = Collection->Entries.FindByPredicate(
 			[&](const FPCGExActorCollectionEntry& E)
 			{
-				return E.DeltaSourceActorName == ActorFName
-					&& E.DeltaSourceLevel.ToSoftObjectPath() == WorldPath;
+				return E.DeltaSourceActor == ActorRef;
 			});
 
 		if (Existing)
@@ -38,8 +37,7 @@ namespace PCGExActorCollectionEditor
 		{
 			FPCGExActorCollectionEntry& New = Collection->Entries.Emplace_GetRef();
 			New.Actor = ActorClass;
-			New.DeltaSourceLevel = TSoftObjectPtr<UWorld>(WorldPath);
-			New.DeltaSourceActorName = ActorFName;
+			New.DeltaSourceActor = ActorRef;
 		}
 	}
 }
@@ -72,29 +70,19 @@ void FPCGExActorCollectionEditor::BuildAssetHeaderToolbar(FToolBarBuilder& Toolb
 								return;
 							}
 
-							const FSoftObjectPath CurrentWorldPath(World);
+							const FName CurrentWorldPackage = World->GetPackage()->GetFName();
 							Collection->Modify();
 
+							// The current level is loaded, so a path that no longer resolves is a missing actor.
 							const int32 Removed = Collection->Entries.RemoveAll(
 								[&](const FPCGExActorCollectionEntry& E)
 								{
-									if (E.DeltaSourceLevel.ToSoftObjectPath() != CurrentWorldPath)
+									const FSoftObjectPath& Path = E.DeltaSourceActor.ToSoftObjectPath();
+									if (!Path.IsValid() || Path.GetLongPackageFName() != CurrentWorldPackage)
 									{
 										return false;
 									}
-									if (E.DeltaSourceActorName == NAME_None)
-									{
-										return false;
-									}
-
-									for (const AActor* Actor : World->PersistentLevel->Actors)
-									{
-										if (Actor && Actor->GetFName() == E.DeltaSourceActorName)
-										{
-											return false;
-										}
-									}
-									return true;
+									return Path.ResolveObject() == nullptr;
 								});
 
 							if (Removed > 0)
@@ -123,15 +111,10 @@ void FPCGExActorCollectionEditor::BuildAssetHeaderToolbar(FToolBarBuilder& Toolb
 							const int32 Removed = Collection->Entries.RemoveAll(
 								[](const FPCGExActorCollectionEntry& E)
 								{
-									if (!E.DeltaSourceLevel.IsNull())
+									if (!E.DeltaSourceActor.IsNull())
 									{
-										const FString PackageName = E.DeltaSourceLevel.ToSoftObjectPath().GetLongPackageName();
+										const FString PackageName = E.DeltaSourceActor.ToSoftObjectPath().GetLongPackageName();
 										if (PackageName.IsEmpty() || !FPackageName::DoesPackageExist(PackageName))
-										{
-											return true;
-										}
-
-										if (E.DeltaSourceActorName == NAME_None)
 										{
 											return true;
 										}
@@ -155,7 +138,7 @@ void FPCGExActorCollectionEditor::BuildAssetHeaderToolbar(FToolBarBuilder& Toolb
 				),
 			NAME_None,
 			FText::GetEmpty(),
-			INVTEXT("Cleanup\nRemove broken entries:\n- Delta source level that no longer exists\n- Incomplete delta references (level set but no actor name)\n- Empty entries (no actor class and no subcollection)"),
+			INVTEXT("Cleanup\nRemove broken entries:\n- Delta source actor whose level no longer exists\n- Empty entries (no actor class and no subcollection)"),
 			FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Adjust")
 			);
 	}

--- a/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExAssetEntryCustomization.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExAssetEntryCustomization.cpp
@@ -3,6 +3,8 @@
 
 #include "Details/Collections/PCGExAssetEntryCustomization.h"
 
+#include "UObject/Package.h"
+
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
 #include "Editor.h"
@@ -272,19 +274,17 @@ TSharedRef<IPropertyTypeCustomization> FPCGExActorEntryCustomization::MakeInstan
 void FPCGExActorEntryCustomization::FillCustomizedTopLevelPropertiesNames()
 {
 	FPCGExEntryHeaderCustomizationBase::FillCustomizedTopLevelPropertiesNames();
-	CustomizedTopLevelProperties.Add(FName("DeltaSourceLevel"));
-	CustomizedTopLevelProperties.Add(FName("DeltaSourceActorName"));
+	CustomizedTopLevelProperties.Add(FName("DeltaSourceActor"));
 }
 
 namespace PCGExActorEntryCustomization
 {
 	static TSharedRef<SWidget> MakePickButton(
 		TSharedPtr<IPropertyHandle> ActorClassHandle,
-		TSharedPtr<IPropertyHandle> DeltaSourceLevelHandle,
-		TSharedPtr<IPropertyHandle> DeltaSourceActorNameHandle)
+		TSharedPtr<IPropertyHandle> DeltaSourceActorHandle)
 	{
 		return PropertyCustomizationHelpers::MakeUseSelectedButton(
-			FSimpleDelegate::CreateLambda([ActorClassHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle]()
+			FSimpleDelegate::CreateLambda([ActorClassHandle, DeltaSourceActorHandle]()
 			{
 				if (!GEditor)
 				{
@@ -316,65 +316,42 @@ namespace PCGExActorEntryCustomization
 					}
 				}
 
-				DeltaSourceActorNameHandle->SetValue(SelectedActor->GetFName());
-
-				FSoftObjectPath WorldPath(SelectedActor->GetWorld());
-				DeltaSourceLevelHandle->SetValueFromFormattedString(WorldPath.ToString());
+				DeltaSourceActorHandle->SetValueFromFormattedString(FSoftObjectPath(SelectedActor).ToString());
 			}),
 			FText::FromString(TEXT("Pick the currently selected actor from the viewport")));
 	}
 
-	static TSharedRef<SWidget> MakeGoToButton(
-		TSharedPtr<IPropertyHandle> DeltaSourceLevelHandle,
-		TSharedPtr<IPropertyHandle> DeltaSourceActorNameHandle)
+	static FSoftObjectPath GetDeltaSourcePath(const TSharedPtr<IPropertyHandle>& DeltaSourceActorHandle)
+	{
+		FString PathStr;
+		DeltaSourceActorHandle->GetValueAsFormattedString(PathStr);
+		return FSoftObjectPath(PathStr);
+	}
+
+	static TSharedRef<SWidget> MakeGoToButton(TSharedPtr<IPropertyHandle> DeltaSourceActorHandle)
 	{
 		return PropertyCustomizationHelpers::MakeBrowseButton(
-			FSimpleDelegate::CreateLambda([DeltaSourceLevelHandle, DeltaSourceActorNameHandle]()
+			FSimpleDelegate::CreateLambda([DeltaSourceActorHandle]()
 			{
 				if (!GEditor)
 				{
 					return;
 				}
 
-				FString LevelPathStr;
-				DeltaSourceLevelHandle->GetValueAsFormattedString(LevelPathStr);
-
-				FName ActorName;
-				DeltaSourceActorNameHandle->GetValue(ActorName);
-
-				if (LevelPathStr.IsEmpty() || ActorName == NAME_None)
+				const FSoftObjectPath ActorPath = GetDeltaSourcePath(DeltaSourceActorHandle);
+				if (!ActorPath.IsValid())
 				{
 					return;
 				}
 
-				// Check if we need to load a different map
-				FSoftObjectPath StoredLevelPath(LevelPathStr);
+				// Open the actor's map when another one is current; the path then resolves live.
 				UWorld* CurrentWorld = GEditor->GetEditorWorldContext().World();
-				FSoftObjectPath CurrentWorldPath(CurrentWorld);
-
-				if (CurrentWorldPath != StoredLevelPath)
+				if (!CurrentWorld || CurrentWorld->GetPackage()->GetFName() != ActorPath.GetLongPackageFName())
 				{
-					FEditorFileUtils::LoadMap(StoredLevelPath.GetLongPackageName());
+					FEditorFileUtils::LoadMap(ActorPath.GetLongPackageName());
 				}
 
-				// Find the actor in the (now current) world
-				UWorld* World = GEditor->GetEditorWorldContext().World();
-				if (!World || !World->PersistentLevel)
-				{
-					return;
-				}
-
-				AActor* FoundActor = nullptr;
-				for (AActor* LevelActor : World->PersistentLevel->Actors)
-				{
-					if (LevelActor && LevelActor->GetFName() == ActorName)
-					{
-						FoundActor = LevelActor;
-						break;
-					}
-				}
-
-				if (FoundActor)
+				if (AActor* FoundActor = Cast<AActor>(ActorPath.ResolveObject()))
 				{
 					GEditor->SelectNone(false, true);
 					GEditor->SelectActor(FoundActor, true, true);
@@ -384,15 +361,9 @@ namespace PCGExActorEntryCustomization
 			FText::FromString(TEXT("Go to the delta source actor in its level")));
 	}
 
-	static bool HasDeltaSource(
-		const TSharedPtr<IPropertyHandle>& DeltaSourceLevelHandle,
-		const TSharedPtr<IPropertyHandle>& DeltaSourceActorNameHandle)
+	static bool HasDeltaSource(const TSharedPtr<IPropertyHandle>& DeltaSourceActorHandle)
 	{
-		FString LevelStr;
-		DeltaSourceLevelHandle->GetValueAsFormattedString(LevelStr);
-		FName ActorName;
-		DeltaSourceActorNameHandle->GetValue(ActorName);
-		return FSoftObjectPath(LevelStr).IsValid() && ActorName != NAME_None;
+		return GetDeltaSourcePath(DeltaSourceActorHandle).IsValid();
 	}
 }
 
@@ -403,8 +374,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 	TSharedPtr<IPropertyHandle> SubCollection = PropertyHandle->GetChildHandle(FName("SubCollection"));
 	TSharedPtr<IPropertyHandle> AssetHandle = PropertyHandle->GetChildHandle(GetAssetName());
 	TSharedPtr<IPropertyHandle> ActorClassHandle = AssetHandle;
-	TSharedPtr<IPropertyHandle> DeltaSourceLevelHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceLevel"));
-	TSharedPtr<IPropertyHandle> DeltaSourceActorNameHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceActorName"));
+	TSharedPtr<IPropertyHandle> DeltaSourceActorHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceActor"));
 
 	return SNew(SHorizontalBox)
 			PCGEX_ENTRY_INDEX
@@ -430,7 +400,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 			.Padding(2, 0)
 			[
 				SNew(SBox)
-				.Visibility_Lambda([IsSubCollectionHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle]()
+				.Visibility_Lambda([IsSubCollectionHandle, DeltaSourceActorHandle]()
 				{
 					bool bSub = false;
 					IsSubCollectionHandle->GetValue(bSub);
@@ -438,7 +408,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 					{
 						return EVisibility::Collapsed;
 					}
-					return PCGExActorEntryCustomization::HasDeltaSource(DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+					return PCGExActorEntryCustomization::HasDeltaSource(DeltaSourceActorHandle)
 						? EVisibility::Collapsed
 						: EVisibility::Visible;
 				})
@@ -454,7 +424,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 					.HAlign(HAlign_Left)
 					.Padding(0, 2, 0, 0)
 					[
-						PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+						PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceActorHandle)
 					]
 				]
 			]
@@ -465,7 +435,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 			.Padding(2, 0)
 			[
 				SNew(SBox)
-				.Visibility_Lambda([IsSubCollectionHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle]()
+				.Visibility_Lambda([IsSubCollectionHandle, DeltaSourceActorHandle]()
 				{
 					bool bSub = false;
 					IsSubCollectionHandle->GetValue(bSub);
@@ -473,7 +443,7 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 					{
 						return EVisibility::Collapsed;
 					}
-					return PCGExActorEntryCustomization::HasDeltaSource(DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+					return PCGExActorEntryCustomization::HasDeltaSource(DeltaSourceActorHandle)
 						? EVisibility::Visible
 						: EVisibility::Collapsed;
 				})
@@ -484,28 +454,21 @@ TSharedRef<SWidget> FPCGExActorEntryCustomization::GetAssetPicker(
 					.VAlign(VAlign_Center)
 					.Padding(2, 0)
 					[
-						DeltaSourceLevelHandle->CreatePropertyValueWidget()
-					]
-					+ SHorizontalBox::Slot()
-					.FillWidth(1)
-					.VAlign(VAlign_Center)
-					.Padding(2, 0)
-					[
-						DeltaSourceActorNameHandle->CreatePropertyValueWidget()
+						DeltaSourceActorHandle->CreatePropertyValueWidget()
 					]
 					+ SHorizontalBox::Slot()
 					.AutoWidth()
 					.VAlign(VAlign_Center)
 					.Padding(2, 0)
 					[
-						PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+						PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceActorHandle)
 					]
 					+ SHorizontalBox::Slot()
 					.AutoWidth()
 					.VAlign(VAlign_Center)
 					.Padding(2, 0)
 					[
-						PCGExActorEntryCustomization::MakeGoToButton(DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+						PCGExActorEntryCustomization::MakeGoToButton(DeltaSourceActorHandle)
 					]
 				]
 			];
@@ -521,10 +484,9 @@ void FPCGExActorEntryCustomization::CustomizeChildren(
 
 	TSharedPtr<IPropertyHandle> IsSubCollectionHandle = PropertyHandle->GetChildHandle(FName("bIsSubCollection"));
 	TSharedPtr<IPropertyHandle> ActorClassHandle = PropertyHandle->GetChildHandle(FName("Actor"));
-	TSharedPtr<IPropertyHandle> DeltaSourceLevelHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceLevel"));
-	TSharedPtr<IPropertyHandle> DeltaSourceActorNameHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceActorName"));
+	TSharedPtr<IPropertyHandle> DeltaSourceActorHandle = PropertyHandle->GetChildHandle(FName("DeltaSourceActor"));
 
-	if (!DeltaSourceLevelHandle.IsValid() || !DeltaSourceActorNameHandle.IsValid())
+	if (!DeltaSourceActorHandle.IsValid())
 	{
 		return;
 	}
@@ -541,20 +503,20 @@ void FPCGExActorEntryCustomization::CustomizeChildren(
 	            }))
 	            .NameContent()
 		[
-			DeltaSourceLevelHandle->CreatePropertyValueWidget()
+			DeltaSourceActorHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MinDesiredWidth(300)
 		[
 			SNew(SHorizontalBox)
 
-			// Actor name
+			// Actor reference
 			+ SHorizontalBox::Slot()
 			.FillWidth(1)
 			.VAlign(VAlign_Center)
 			.Padding(2, 0)
 			[
-				DeltaSourceActorNameHandle->CreatePropertyValueWidget()
+				DeltaSourceActorHandle->CreatePropertyValueWidget()
 			]
 
 			// Pick from selected actor
@@ -563,7 +525,7 @@ void FPCGExActorEntryCustomization::CustomizeChildren(
 			.VAlign(VAlign_Center)
 			.Padding(2, 0)
 			[
-				PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+				PCGExActorEntryCustomization::MakePickButton(ActorClassHandle, DeltaSourceActorHandle)
 			]
 
 			// Go to delta source actor
@@ -572,7 +534,7 @@ void FPCGExActorEntryCustomization::CustomizeChildren(
 			.VAlign(VAlign_Center)
 			.Padding(2, 0)
 			[
-				PCGExActorEntryCustomization::MakeGoToButton(DeltaSourceLevelHandle, DeltaSourceActorNameHandle)
+				PCGExActorEntryCustomization::MakeGoToButton(DeltaSourceActorHandle)
 			]
 		];
 }
@@ -594,6 +556,7 @@ void FPCGExPCGDataAssetEntryCustomization::FillCustomizedTopLevelPropertiesNames
 	CustomizedTopLevelProperties.Add(FName("Source"));
 	CustomizedTopLevelProperties.Add(FName("DataAsset"));
 	CustomizedTopLevelProperties.Add(FName("Level"));
+	CustomizedTopLevelProperties.Add(FName("SourceActor"));
 }
 
 TSharedRef<SWidget> FPCGExPCGDataAssetEntryCustomization::GetAssetPicker(TSharedRef<IPropertyHandle> PropertyHandle, TSharedPtr<IPropertyHandle> IsSubCollectionHandle)
@@ -602,6 +565,25 @@ TSharedRef<SWidget> FPCGExPCGDataAssetEntryCustomization::GetAssetPicker(TShared
 	TSharedPtr<IPropertyHandle> SourceHandle = PropertyHandle->GetChildHandle(FName("Source"));
 	TSharedPtr<IPropertyHandle> DataAssetHandle = PropertyHandle->GetChildHandle(FName("DataAsset"));
 	TSharedPtr<IPropertyHandle> LevelHandle = PropertyHandle->GetChildHandle(FName("Level"));
+	TSharedPtr<IPropertyHandle> SourceActorHandle = PropertyHandle->GetChildHandle(FName("SourceActor"));
+
+	auto VisibleForSource = [IsSubCollectionHandle, SourceHandle](const EPCGExDataAssetEntrySource Wanted)
+	{
+		return [IsSubCollectionHandle, SourceHandle, Wanted]()
+		{
+			bool bIsSubCollection = false;
+			IsSubCollectionHandle->GetValue(bIsSubCollection);
+			if (bIsSubCollection)
+			{
+				return EVisibility::Collapsed;
+			}
+			uint8 SourceValue = 0;
+			SourceHandle->GetValue(SourceValue);
+			return static_cast<EPCGExDataAssetEntrySource>(SourceValue) == Wanted
+				? EVisibility::Visible
+				: EVisibility::Collapsed;
+		};
+	};
 
 	return SNew(SHorizontalBox)
 			PCGEX_ENTRY_INDEX
@@ -642,20 +624,7 @@ TSharedRef<SWidget> FPCGExPCGDataAssetEntryCustomization::GetAssetPicker(TShared
 			[
 				SNew(SBox)
 				.ToolTipText(DataAssetHandle->GetToolTipText())
-				.Visibility_Lambda([IsSubCollectionHandle, SourceHandle]()
-				{
-					bool bIsSubCollection = false;
-					IsSubCollectionHandle->GetValue(bIsSubCollection);
-					if (bIsSubCollection)
-					{
-						return EVisibility::Collapsed;
-					}
-					uint8 SourceValue = 0;
-					SourceHandle->GetValue(SourceValue);
-					return static_cast<EPCGExDataAssetEntrySource>(SourceValue) == EPCGExDataAssetEntrySource::DataAsset
-						? EVisibility::Visible
-						: EVisibility::Collapsed;
-				})
+				.Visibility_Lambda(VisibleForSource(EPCGExDataAssetEntrySource::DataAsset))
 				[
 					DataAssetHandle->CreatePropertyValueWidget()
 				]
@@ -669,22 +638,23 @@ TSharedRef<SWidget> FPCGExPCGDataAssetEntryCustomization::GetAssetPicker(TShared
 			[
 				SNew(SBox)
 				.ToolTipText(LevelHandle->GetToolTipText())
-				.Visibility_Lambda([IsSubCollectionHandle, SourceHandle]()
-				{
-					bool bIsSubCollection = false;
-					IsSubCollectionHandle->GetValue(bIsSubCollection);
-					if (bIsSubCollection)
-					{
-						return EVisibility::Collapsed;
-					}
-					uint8 SourceValue = 0;
-					SourceHandle->GetValue(SourceValue);
-					return static_cast<EPCGExDataAssetEntrySource>(SourceValue) == EPCGExDataAssetEntrySource::Level
-						? EVisibility::Visible
-						: EVisibility::Collapsed;
-				})
+				.Visibility_Lambda(VisibleForSource(EPCGExDataAssetEntrySource::Level))
 				[
 					LevelHandle->CreatePropertyValueWidget()
+				]
+			]
+
+			// Actor picker (when !subcollection && Source == Actor)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1)
+			.MinWidth(200)
+			.Padding(2, 0)
+			[
+				SNew(SBox)
+				.ToolTipText(SourceActorHandle->GetToolTipText())
+				.Visibility_Lambda(VisibleForSource(EPCGExDataAssetEntrySource::Actor))
+				[
+					SourceActorHandle->CreatePropertyValueWidget()
 				]
 			];
 }

--- a/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExCollectionEditorUtils.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExCollectionEditorUtils.cpp
@@ -109,6 +109,17 @@ namespace PCGExCollectionEditorUtils
 			}
 		}
 
+		// Embedded objects (an entry's exported data asset) have no registry row. A live one answers:
+		// FAssetData built from the object keeps its outer path, so the thumbnail pool resolves and
+		// renders it through the class renderer like any asset.
+		if (!AssetData.IsValid() && AssetPath.IsSubobject())
+		{
+			if (const UObject* Object = AssetPath.ResolveObject())
+			{
+				AssetData = FAssetData(Object);
+			}
+		}
+
 		return AssetData;
 	}
 

--- a/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExPCGDataAssetCollectionEditor.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Details/Collections/PCGExPCGDataAssetCollectionEditor.cpp
@@ -9,6 +9,7 @@
 #include "Collections/PCGExPCGDataAssetCollection.h"
 #include "Core/PCGExAssetCollection.h"
 #include "Engine/World.h"
+#include "GameFramework/Actor.h"
 #include "UObject/UnrealType.h"
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Input/SComboBox.h"
@@ -20,6 +21,7 @@ FPCGExPCGDataAssetCollectionEditor::FPCGExPCGDataAssetCollectionEditor()
 {
 	SourceOptions.Add(MakeShared<FString>(TEXT("Data Asset")));
 	SourceOptions.Add(MakeShared<FString>(TEXT("Level")));
+	SourceOptions.Add(MakeShared<FString>(TEXT("Actor")));
 }
 
 TSharedRef<SWidget> FPCGExPCGDataAssetCollectionEditor::BuildTilePickerWidget(
@@ -33,6 +35,7 @@ TSharedRef<SWidget> FPCGExPCGDataAssetCollectionEditor::BuildTilePickerWidget(
 	static const FName SourcePropName = GET_MEMBER_NAME_CHECKED(FPCGExPCGDataAssetCollectionEntry, Source);
 	static const FName DataAssetPropName = GET_MEMBER_NAME_CHECKED(FPCGExPCGDataAssetCollectionEntry, DataAsset);
 	static const FName LevelPropName = GET_MEMBER_NAME_CHECKED(FPCGExPCGDataAssetCollectionEntry, Level);
+	static const FName SourceActorPropName = GET_MEMBER_NAME_CHECKED(FPCGExPCGDataAssetCollectionEntry, SourceActor);
 
 	auto GetTypedEntry = [WeakColl, Idx]() -> FPCGExPCGDataAssetCollectionEntry*
 	{
@@ -95,9 +98,15 @@ TSharedRef<SWidget> FPCGExPCGDataAssetCollectionEditor::BuildTilePickerWidget(
 					return;
 				}
 
-				const EPCGExDataAssetEntrySource NewSource = (*Selected == TEXT("Level"))
-					? EPCGExDataAssetEntrySource::Level
-					: EPCGExDataAssetEntrySource::DataAsset;
+				EPCGExDataAssetEntrySource NewSource = EPCGExDataAssetEntrySource::DataAsset;
+				if (*Selected == TEXT("Level"))
+				{
+					NewSource = EPCGExDataAssetEntrySource::Level;
+				}
+				else if (*Selected == TEXT("Actor"))
+				{
+					NewSource = EPCGExDataAssetEntrySource::Actor;
+				}
 
 				if (Entry->Source == NewSource)
 				{
@@ -119,9 +128,15 @@ TSharedRef<SWidget> FPCGExPCGDataAssetCollectionEditor::BuildTilePickerWidget(
 					{
 						return INVTEXT("?");
 					}
-					return Entry->Source == EPCGExDataAssetEntrySource::Level
-						? INVTEXT("Level")
-						: INVTEXT("Data Asset");
+					switch (Entry->Source)
+					{
+					case EPCGExDataAssetEntrySource::Level:
+						return INVTEXT("Level");
+					case EPCGExDataAssetEntrySource::Actor:
+						return INVTEXT("Actor");
+					default:
+						return INVTEXT("Data Asset");
+					}
 				})
 				.Font(FCoreStyle::GetDefaultFontStyle("Regular", 8))
 			]
@@ -231,6 +246,61 @@ TSharedRef<SWidget> FPCGExPCGDataAssetCollectionEditor::BuildTilePickerWidget(
 				Entry->Level = TSoftObjectPtr<UWorld>(AssetData.GetSoftObjectPath());
 				Coll->PostEditChange();
 				OnPropertyEdited.ExecuteIfBound(LevelPropName);
+			})
+			.DisplayThumbnail(false)
+		]
+	];
+
+	// Actor picker (when Source == Actor and not subcollection). SObjectPropertyEntryBox on an
+	// actor class offers the level actor picker.
+	Box->AddSlot()
+	   .AutoHeight()
+	[
+		SNew(SBox)
+		.Visibility_Lambda([GetTypedEntry, WeakColl, Idx]()
+		{
+			const UPCGExAssetCollection* Coll = WeakColl.Get();
+			if (!Coll)
+			{
+				return EVisibility::Collapsed;
+			}
+			const FPCGExEntryAccessResult Result = Coll->GetEntryRaw(Idx);
+			if (!Result.IsValid() || Result.Entry->bIsSubCollection)
+			{
+				return EVisibility::Collapsed;
+			}
+			const FPCGExPCGDataAssetCollectionEntry* Entry = GetTypedEntry();
+			return (Entry && Entry->Source == EPCGExDataAssetEntrySource::Actor) ? EVisibility::Visible : EVisibility::Collapsed;
+		})
+		[
+			SNew(SObjectPropertyEntryBox)
+			.AllowedClass(AActor::StaticClass())
+			.ObjectPath_Lambda([GetTypedEntry]() -> FString
+			{
+				const FPCGExPCGDataAssetCollectionEntry* Entry = GetTypedEntry();
+				if (!Entry)
+				{
+					return FString();
+				}
+				return Entry->SourceActor.ToSoftObjectPath().ToString();
+			})
+			.OnObjectChanged_Lambda([GetTypedEntry, WeakColl, OnPropertyEdited](const FAssetData& AssetData)
+			{
+				UPCGExAssetCollection* Coll = WeakColl.Get();
+				if (!Coll)
+				{
+					return;
+				}
+				FPCGExPCGDataAssetCollectionEntry* Entry = GetTypedEntry();
+				if (!Entry)
+				{
+					return;
+				}
+				FScopedTransaction Transaction(INVTEXT("Set Source Actor"));
+				Coll->Modify();
+				Entry->SourceActor = TSoftObjectPtr<AActor>(AssetData.GetSoftObjectPath());
+				Coll->PostEditChange();
+				OnPropertyEdited.ExecuteIfBound(SourceActorPropName);
 			})
 			.DisplayThumbnail(false)
 		]

--- a/Source/PCGExCollectionsEditor/Private/Details/Collections/SPCGExCollectionGridTile.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Details/Collections/SPCGExCollectionGridTile.cpp
@@ -871,7 +871,7 @@ FReply SPCGExCollectionGridTile::OnMouseButtonDoubleClick(const FGeometry& MyGeo
 		return FReply::Unhandled();
 	}
 
-	const FSoftObjectPath AssetPath = Result.Entry->EDITOR_GetThumbnailAssetPath();
+	const FSoftObjectPath AssetPath = Result.Entry->EDITOR_GetActivationAssetPath();
 	if (AssetPath.IsNull())
 	{
 		return FReply::Unhandled();

--- a/Source/PCGExCollectionsEditor/Private/PCGExCollectionsEditor.cpp
+++ b/Source/PCGExCollectionsEditor/Private/PCGExCollectionsEditor.cpp
@@ -187,9 +187,17 @@ void FPCGExCollectionsEditorModule::OnAssetUpdatedOnDisk(const FAssetData& Asset
 		return;
 	}
 
+	// An external (OFPA) actor saves into its own package, which no collection references: the
+	// registry stores its outer under the LEVEL ("/Game/Maps/M.M:PersistentLevel"), so the actor's
+	// object path -- and therefore its long package name -- is the level's. Walk that instead.
+	// Source paths on entries are level-rooted too, so the package-name match below still holds.
+	const FName ReferencedPackage = AssetData.GetOptionalOuterPathName().IsNone()
+		? AssetData.PackageName
+		: AssetData.GetSoftObjectPath().GetLongPackageFName();
+
 	// Find packages that reference this asset (no load).
 	TArray<FName> Referencers;
-	AssetRegistry.GetReferencers(AssetData.PackageName, Referencers, UE::AssetRegistry::EDependencyCategory::Package);
+	AssetRegistry.GetReferencers(ReferencedPackage, Referencers, UE::AssetRegistry::EDependencyCategory::Package);
 	if (Referencers.IsEmpty())
 	{
 		return;
@@ -224,7 +232,7 @@ void FPCGExCollectionsEditorModule::OnAssetUpdatedOnDisk(const FAssetData& Asset
 			// a rebuild when updated on disk -- which for some entry types (e.g. PCGDataAsset
 			// entries in Level mode) is NOT Staging.Path. Matching by package name also
 			// handles BP class paths where the path ends in "_C".
-			Collection->ForEachEntry([Collection, &AssetData](const FPCGExAssetCollectionEntry* InEntry, int32 i)
+			Collection->ForEachEntry([Collection, ReferencedPackage](const FPCGExAssetCollectionEntry* InEntry, int32 i)
 			{
 				if (InEntry->bIsSubCollection)
 				{
@@ -236,7 +244,7 @@ void FPCGExCollectionsEditorModule::OnAssetUpdatedOnDisk(const FAssetData& Asset
 
 				for (const FSoftObjectPath& SourcePath : SourcePaths)
 				{
-					if (SourcePath.GetLongPackageFName() == AssetData.PackageName)
+					if (SourcePath.GetLongPackageFName() == ReferencedPackage)
 					{
 						Collection->EDITOR_RebuildEntryStaging(i);
 						return;

--- a/Source/PCGExCollectionsEditor/Private/PCGExCollectionsEditor.cpp
+++ b/Source/PCGExCollectionsEditor/Private/PCGExCollectionsEditor.cpp
@@ -40,6 +40,8 @@
 #include "UObject/UObjectIterator.h"
 #include "ThumbnailRendering/ThumbnailManager.h"
 #include "Thumbnails/PCGExCollectionThumbnailRenderer.h"
+#include "Thumbnails/PCGExPCGDataAssetThumbnailRenderer.h"
+#include "PCGDataAsset.h"
 #include "UObject/Package.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/UObjectHash.h"
@@ -164,6 +166,9 @@ void FPCGExCollectionsEditorModule::ShutdownModule()
 void FPCGExCollectionsEditorModule::RegisterThumbnailRenderer()
 {
 	UThumbnailManager::Get().RegisterCustomRenderer(UPCGExAssetCollection::StaticClass(), UPCGExCollectionThumbnailRenderer::StaticClass());
+	// Data assets draw their mesh points -- level and assembly exports show their geometry in the
+	// collection grid and the content browser instead of the class icon.
+	UThumbnailManager::Get().RegisterCustomRenderer(UPCGDataAsset::StaticClass(), UPCGExPCGDataAssetThumbnailRenderer::StaticClass());
 	bThumbnailRendererRegistered = true;
 }
 

--- a/Source/PCGExCollectionsEditor/Private/Thumbnails/PCGExPCGDataAssetThumbnailRenderer.cpp
+++ b/Source/PCGExCollectionsEditor/Private/Thumbnails/PCGExPCGDataAssetThumbnailRenderer.cpp
@@ -1,0 +1,309 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "Thumbnails/PCGExPCGDataAssetThumbnailRenderer.h"
+
+#include "PCGDataAsset.h"
+#include "PCGExCollectionsCommon.h"
+#include "PCGParamData.h"
+#include "RenderingThread.h"
+#include "SceneInterface.h"
+#include "SceneView.h"
+#include "ShowFlags.h"
+#include "ThumbnailHelpers.h"
+#include "Collections/PCGExMeshCollection.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/SceneComponent.h"
+#include "Core/PCGExAssetCollection.h"
+#include "Data/PCGBasePointData.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Helpers/PCGExCollectionsHelpers.h"
+#include "Metadata/PCGMetadata.h"
+#include "Metadata/PCGMetadataAttribute.h"
+#include "ThumbnailRendering/SceneThumbnailInfo.h"
+
+namespace PCGExPCGDataAssetThumbnail
+{
+	/** Instances past this are dropped: a thumbnail is a glance, not a render of a city. */
+	constexpr int32 MaxInstances = 4096;
+
+	/** Every mesh point of the asset, grouped by resolved mesh. Empty when nothing resolves. */
+	void GatherMeshInstances(const UPCGDataAsset* Asset, TMap<UStaticMesh*, TArray<FTransform>>& OutInstances)
+	{
+		OutInstances.Reset();
+		if (!Asset)
+		{
+			return;
+		}
+
+		// Collections first: the CollectionMap pin lists every collection the point hashes resolve
+		// through. Loaded here rather than through the unpacker's own reader, which logs through a
+		// PCG context this renderer does not have.
+		PCGExCollections::FPickUnpacker Unpacker;
+		for (const FPCGTaggedData& TaggedData : Asset->Data.TaggedData)
+		{
+			if (TaggedData.Pin != PCGExCollections::Labels::CollectionMapPin)
+			{
+				continue;
+			}
+			const UPCGParamData* MapData = Cast<UPCGParamData>(TaggedData.Data);
+			if (!MapData || !MapData->Metadata)
+			{
+				continue;
+			}
+			const FPCGMetadataAttribute<FSoftObjectPath>* PathAttr = MapData->Metadata->GetConstTypedAttribute<FSoftObjectPath>(PCGExCollections::Labels::Tag_CollectionPath);
+			if (!PathAttr)
+			{
+				continue;
+			}
+			const int64 NumRows = MapData->Metadata->GetItemCountForChild();
+			for (int64 Row = 0; Row < NumRows; Row++)
+			{
+				const FSoftObjectPath Path = PathAttr->GetValueFromItemKey(Row);
+				if (UPCGExAssetCollection* Collection = Cast<UPCGExAssetCollection>(Path.TryLoad()))
+				{
+					Unpacker.AddCollection(Collection);
+				}
+			}
+		}
+
+		int32 Budget = MaxInstances;
+		for (const FPCGTaggedData& TaggedData : Asset->Data.TaggedData)
+		{
+			if (TaggedData.Pin != PCGExCollections::Labels::MeshesPin)
+			{
+				continue;
+			}
+			const UPCGBasePointData* Points = Cast<UPCGBasePointData>(TaggedData.Data);
+			if (!Points || Points->GetNumPoints() == 0)
+			{
+				continue;
+			}
+
+			const UPCGMetadata* Metadata = Points->ConstMetadata();
+			const FPCGMetadataAttribute<int64>* HashAttr = Metadata ? Metadata->GetConstTypedAttribute<int64>(PCGExCollections::Labels::Tag_EntryIdx) : nullptr;
+			const FPCGMetadataAttribute<FSoftObjectPath>* MeshAttr = Metadata ? Metadata->GetConstTypedAttribute<FSoftObjectPath>(TEXT("Mesh")) : nullptr;
+			if (!HashAttr && !MeshAttr)
+			{
+				continue;
+			}
+
+			const TConstPCGValueRange<FTransform> Transforms = Points->GetConstTransformValueRange();
+			const TConstPCGValueRange<int64> MetadataEntries = Points->GetConstMetadataEntryValueRange();
+			const int32 NumPoints = Points->GetNumPoints();
+
+			for (int32 i = 0; i < NumPoints && Budget > 0; i++)
+			{
+				UStaticMesh* Mesh = nullptr;
+				const int64 MetadataEntry = MetadataEntries[i];
+
+				if (HashAttr && Unpacker.HasValidMapping())
+				{
+					const int64 Hash = HashAttr->GetValueFromItemKey(MetadataEntry);
+					if (Hash != 0 && Hash != -1)
+					{
+						int16 SecondaryIndex = 0;
+						const FPCGExEntryAccessResult Result = Unpacker.ResolveEntry(static_cast<uint64>(Hash), SecondaryIndex);
+						if (Result.IsValid() && Result.Entry->IsType(PCGExAssetCollection::TypeIds::Mesh))
+						{
+							Mesh = static_cast<const FPCGExMeshCollectionEntry*>(Result.Entry)->StaticMesh.LoadSynchronous();
+						}
+					}
+				}
+				if (!Mesh && MeshAttr)
+				{
+					Mesh = Cast<UStaticMesh>(MeshAttr->GetValueFromItemKey(MetadataEntry).TryLoad());
+				}
+				if (!Mesh)
+				{
+					continue;
+				}
+
+				OutInstances.FindOrAdd(Mesh).Add(Transforms[i]);
+				Budget--;
+			}
+		}
+	}
+}
+
+/**
+ * Preview scene holding one transient actor with one ISM component per mesh. Rebuilt per draw:
+ * SetDataAsset populates, Clear tears the components down.
+ */
+class FPCGExDataAssetThumbnailScene final : public FThumbnailPreviewScene
+{
+public:
+	FPCGExDataAssetThumbnailScene()
+		: FThumbnailPreviewScene()
+	{
+		bForceAllUsedMipsResident = false;
+
+		FActorSpawnParameters SpawnInfo;
+		SpawnInfo.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+		SpawnInfo.bNoFail = true;
+		SpawnInfo.ObjectFlags = RF_Transient;
+		AActor* Actor = GetWorld()->SpawnActor<AActor>(SpawnInfo);
+
+		USceneComponent* Root = NewObject<USceneComponent>(Actor, TEXT("Root"), RF_Transient);
+		Root->SetMobility(EComponentMobility::Movable);
+		Actor->SetRootComponent(Root);
+		Root->RegisterComponentWithWorld(GetWorld());
+		Actor->SetActorEnableCollision(false);
+
+		PreviewActor = Actor;
+	}
+
+	bool SetDataAsset(const UPCGDataAsset* Asset)
+	{
+		Clear();
+
+		AActor* Actor = PreviewActor.Get();
+		if (!Actor || !Actor->GetRootComponent())
+		{
+			return false;
+		}
+
+		TMap<UStaticMesh*, TArray<FTransform>> Instances;
+		PCGExPCGDataAssetThumbnail::GatherMeshInstances(Asset, Instances);
+		if (Instances.IsEmpty())
+		{
+			return false;
+		}
+
+		FBoxSphereBounds::Builder BoundsBuilder;
+		for (const TPair<UStaticMesh*, TArray<FTransform>>& Pair : Instances)
+		{
+			UInstancedStaticMeshComponent* ISM = NewObject<UInstancedStaticMeshComponent>(Actor, NAME_None, RF_Transient);
+			ISM->SetStaticMesh(Pair.Key);
+			ISM->SetMobility(EComponentMobility::Movable);
+			ISM->SetCanEverAffectNavigation(false);
+			ISM->bSelectable = false;
+			ISM->ForcedLodModel = 1;
+			ISM->AttachToComponent(Actor->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+			ISM->RegisterComponentWithWorld(GetWorld());
+			ISM->AddInstances(Pair.Value, /*bShouldReturnIndices=*/false);
+			ISM->UpdateBounds();
+			BoundsBuilder += ISM->Bounds;
+			Components.Add(ISM);
+		}
+
+		CachedBounds = BoundsBuilder;
+
+		// Centre the assembly at the origin, resting on the floor plane, the way every engine scene does.
+		Actor->SetActorLocation(-CachedBounds.Origin + FVector(0, 0, GetBoundsZOffset(CachedBounds)), false);
+		for (UInstancedStaticMeshComponent* ISM : Components)
+		{
+			ISM->RecreateRenderState_Concurrent();
+		}
+		return true;
+	}
+
+	void Clear()
+	{
+		for (UInstancedStaticMeshComponent* ISM : Components)
+		{
+			if (ISM)
+			{
+				ISM->DestroyComponent();
+			}
+		}
+		Components.Reset();
+		CachedBounds = FBoxSphereBounds(ForceInit);
+	}
+
+protected:
+	virtual void GetViewMatrixParameters(const float InFOVDegrees, FVector& OutOrigin, float& OutOrbitPitch, float& OutOrbitYaw, float& OutOrbitZoom) const override
+	{
+		const float HalfFOVRadians = FMath::DegreesToRadians<float>(InFOVDegrees) * 0.5f;
+		// Slightly outside the sphere to compensate for perspective -- the engine's own factor.
+		const float HalfMeshSize = static_cast<float>(CachedBounds.SphereRadius * 1.15);
+		const float BoundsZOffset = GetBoundsZOffset(CachedBounds);
+		const float TargetDistance = HalfMeshSize / FMath::Tan(HalfFOVRadians);
+
+		const USceneThumbnailInfo* ThumbnailInfo = USceneThumbnailInfo::StaticClass()->GetDefaultObject<USceneThumbnailInfo>();
+
+		OutOrigin = FVector(0, 0, -BoundsZOffset);
+		OutOrbitPitch = ThumbnailInfo->OrbitPitch;
+		OutOrbitYaw = ThumbnailInfo->OrbitYaw;
+		OutOrbitZoom = TargetDistance + ThumbnailInfo->OrbitZoom;
+	}
+
+private:
+	TWeakObjectPtr<AActor> PreviewActor;
+	TArray<UInstancedStaticMeshComponent*> Components;
+	FBoxSphereBounds CachedBounds = FBoxSphereBounds(ForceInit);
+};
+
+#pragma region UPCGExPCGDataAssetThumbnailRenderer
+
+bool UPCGExPCGDataAssetThumbnailRenderer::CanVisualizeAsset(UObject* Object)
+{
+	const UPCGDataAsset* Asset = Cast<UPCGDataAsset>(Object);
+	if (!Asset)
+	{
+		return false;
+	}
+	for (const FPCGTaggedData& TaggedData : Asset->Data.TaggedData)
+	{
+		if (TaggedData.Pin != PCGExCollections::Labels::MeshesPin)
+		{
+			continue;
+		}
+		if (const UPCGBasePointData* Points = Cast<UPCGBasePointData>(TaggedData.Data); Points && Points->GetNumPoints() > 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void UPCGExPCGDataAssetThumbnailRenderer::Draw(UObject* Object, int32 X, int32 Y, uint32 Width, uint32 Height, FRenderTarget* RenderTarget, FCanvas* Canvas, bool bAdditionalViewFamily)
+{
+	const UPCGDataAsset* Asset = Cast<UPCGDataAsset>(Object);
+	if (!IsValid(Asset))
+	{
+		return;
+	}
+
+	if (ThumbnailScene == nullptr || ensure(ThumbnailScene->GetWorld() != nullptr) == false)
+	{
+		if (ThumbnailScene)
+		{
+			FlushRenderingCommands();
+			delete ThumbnailScene;
+		}
+		ThumbnailScene = new FPCGExDataAssetThumbnailScene();
+	}
+
+	if (!ThumbnailScene->SetDataAsset(Asset))
+	{
+		return;
+	}
+
+	ThumbnailScene->GetScene()->UpdateSpeedTreeWind(0.0);
+
+	FSceneViewFamilyContext ViewFamily(FSceneViewFamily::ConstructionValues(RenderTarget, ThumbnailScene->GetScene(), FEngineShowFlags(ESFIM_Game))
+		.SetTime(UThumbnailRenderer::GetTime())
+		.SetAdditionalViewFamily(bAdditionalViewFamily));
+
+	ViewFamily.EngineShowFlags.DisableAdvancedFeatures();
+	ViewFamily.EngineShowFlags.MotionBlur = 0;
+	ViewFamily.EngineShowFlags.LOD = 0;
+
+	RenderViewFamily(Canvas, &ViewFamily, ThumbnailScene->CreateView(&ViewFamily, X, Y, Width, Height));
+	ThumbnailScene->Clear();
+}
+
+void UPCGExPCGDataAssetThumbnailRenderer::BeginDestroy()
+{
+	if (ThumbnailScene != nullptr)
+	{
+		delete ThumbnailScene;
+		ThumbnailScene = nullptr;
+	}
+	Super::BeginDestroy();
+}
+
+#pragma endregion

--- a/Source/PCGExCollectionsEditor/Public/Thumbnails/PCGExPCGDataAssetThumbnailRenderer.h
+++ b/Source/PCGExCollectionsEditor/Public/Thumbnails/PCGExPCGDataAssetThumbnailRenderer.h
@@ -1,0 +1,50 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ThumbnailRendering/DefaultSizedThumbnailRenderer.h"
+
+#include "PCGExPCGDataAssetThumbnailRenderer.generated.h"
+
+class FCanvas;
+class FRenderTarget;
+class FPCGExDataAssetThumbnailScene;
+
+/**
+ * Thumbnail renderer for UPCGDataAsset (registered on the class by the module). Draws the asset's
+ * "Meshes" pin as instanced static meshes in a preview scene: a level export, an assembly export or
+ * any hand-made data asset carrying mesh points shows its geometry instead of the class icon.
+ *
+ * Mesh per point resolves the way the staging pipeline does -- entry hash through the asset's embedded
+ * CollectionMap pin -- with the exporter's raw "Mesh" attribute as the fallback for assets exported
+ * without collections. Points without a resolvable mesh are skipped; an asset with none is not
+ * visualized (CanVisualizeAsset).
+ *
+ * OnPropertyChange frequency: an embedded export is a fresh object on every re-export, so a stale
+ * cache can never outlive the content it shows.
+ */
+UCLASS()
+class PCGEXCOLLECTIONSEDITOR_API UPCGExPCGDataAssetThumbnailRenderer : public UDefaultSizedThumbnailRenderer
+{
+	GENERATED_BODY()
+
+public:
+	//~ Begin UThumbnailRenderer
+	virtual bool CanVisualizeAsset(UObject* Object) override;
+	virtual void Draw(UObject* Object, int32 X, int32 Y, uint32 Width, uint32 Height, FRenderTarget* Viewport, FCanvas* Canvas, bool bAdditionalViewFamily) override;
+	virtual EThumbnailRenderFrequency GetThumbnailRenderFrequency(UObject* Object) const override
+	{
+		return EThumbnailRenderFrequency::OnPropertyChange;
+	}
+	//~ End UThumbnailRenderer
+
+	//~ Begin UObject
+	virtual void BeginDestroy() override;
+	//~ End UObject
+
+private:
+	/** Owned; created on first draw, torn down with the renderer (the engine's own renderers do the same). */
+	FPCGExDataAssetThumbnailScene* ThumbnailScene = nullptr;
+};

--- a/Source/PCGExtendedToolkitEditor/Private/Details/PCGExDetailsCustomization.cpp
+++ b/Source/PCGExtendedToolkitEditor/Private/Details/PCGExDetailsCustomization.cpp
@@ -149,6 +149,7 @@ namespace PCGExDetailsCustomization
 
 		PCGEX_ADD_ACTION_ICON(PCGDA_DataAsset, AIS_VerySmall)
 		PCGEX_ADD_ACTION_ICON(PCGDA_Level, AIS_VerySmall)
+		PCGEX_ADD_ACTION_ICON(PCGDA_Actor, AIS_VerySmall)
 
 		FButtonStyle ActionIconButton = FAppStyle::Get().GetWidgetStyle<FButtonStyle>("SimpleButton");
 


### PR DESCRIPTION
# Assembly modules: export an actor's subtree as if it were a level

**A PCGDataAsset collection entry can now source from a placed actor**: everything attached under it is exported to the embedded data asset exactly like a level-sourced entry, with points relative to the actor. Any actor can be a root; the new [PCGEx] Assembly Root actor is the ready-made one, and IPCGExAssemblyRoot lets a custom actor decide what the export descends into. Valency gets an Assembly Cage on top of it, plus assembly roots as entries of regular cages.

## API changes you will need to edit

`UPCGExLevelDataExporter::ExportLevelData` (C++ virtual) now takes const `FPCGExLevelExportSource&` instead of `UWorld*`. Custom C++ exporters must override the new signature and route every written transform through Source.ToFrame. The Blueprint event is unchanged.
`FPCGExActorCollectionEntry: DeltaSourceLevel` + `DeltaSourceActorName` are replaced by one `DeltaSourceActor` soft actor reference. Existing assets migrate on load; code reading the old pair must switch.
`EPCGExDataAssetEntrySource` gains `Actor` (appended, existing values untouched). Any switch over it needs the new arm.
Anything calling the raw `UPCGExAssetCollection::RebuildStagingData` on a host with embedded PCGData exports must now also call `EDITOR_RunTypeStatesPostStaging`, or the exports ship with raw attributes and no `CollectionMap`.
New base virtuals available to hosts: `EDITOR_OnHostRelocated`, `EDITOR_GetActivationAssetPath`, and the per-entry OnHostPostLoad.

## Behaviour changes worth knowing

Actor entries pointed at a placed actor resolve it exactly, soft-load a closed level to read it, refuse World Partition levels, and keep the previous delta when the actor is unreachable instead of clearing it.
Every `UPCGDataAsset` with mesh points now draws its geometry as its thumbnail, in collection grids and in the content browser. Level- and actor-sourced entries draw their export; double-click still opens the source level.
A collection host that is renamed or re-outered re-stamps its embedded exports' paths, which fixes externalized generated collections losing their maps.
Footprints in the level cache no longer report a spurious change on the first bake after a level load.