### PR TITLE
[Collections] Add keyed export slots and level export handlers

### DIFF
--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -29,11 +29,12 @@
 #include "Engine/Level.h"
 #include "Helpers/PCGExActorHelpers.h"
 #include "Helpers/PCGExCollectionExternalization.h"
-#include "Helpers/PCGExCollectionSortKeys.h"
 #include "Helpers/PCGExCollectionsHelpers.h"
 #include "Helpers/PCGExDefaultLevelDataExporter.h"
 #include "Helpers/PCGExLevelDataExporter.h"
+#include "Helpers/PCGExLevelExportHandler.h"
 #include "Helpers/PCGExStreamingHelpers.h"
+#include "Core/PCGExCollectionHelpers.h"
 #include "GameFramework/Actor.h"
 
 
@@ -123,11 +124,21 @@ namespace PCGExPCGDataAssetCollectionInternal
 void FPCGExPCGDataAssetCollectionEntry::ResetEditorContributions()
 {
 #if WITH_EDITORONLY_DATA
-	EditorMeshContributions.Reset();
-	EditorMeshInheritedDefaults.Reset();
-	EditorLocalPicks.Reset();
-	EditorLevelContributions.Reset();
-	EditorLevelLocalPicks.Reset();
+#if WITH_EDITOR
+	// Captured entries may own instanced subobjects (handler payloads) outered to the host; an
+	// unreferenced inner would otherwise linger under it until the next save's traversal.
+	for (FPCGExExportSlotCapture& Capture : Captures)
+	{
+		for (FInstancedStruct& Entry : Capture.Entries)
+		{
+			if (Entry.IsValid())
+			{
+				PCGExCollectionHelpers::RetireInstancedSubobjects(Entry.GetScriptStruct(), Entry.GetMutableMemory());
+			}
+		}
+	}
+#endif
+	Captures.Reset();
 #endif
 }
 
@@ -141,7 +152,7 @@ void FPCGExPCGDataAssetCollectionEntry::ResetExport(const UPCGExAssetCollection*
 		{
 			return;
 		}
-		if (Embedded->GetOuter() == OwningCollection)
+		if (OwningCollection && Embedded->IsIn(OwningCollection))
 		{
 			Embedded->Rename(nullptr, GetTransientPackage(),
 			                 REN_DontCreateRedirectors | REN_NonTransactional);
@@ -149,21 +160,91 @@ void FPCGExPCGDataAssetCollectionEntry::ResetExport(const UPCGExAssetCollection*
 		Embedded = nullptr;
 	};
 	Discard(ExportedDataAsset);
-	Discard(EmbeddedActorCollection);
+	for (FPCGExExportCollectionSlot& Slot : EmbeddedSlots)
+	{
+		Discard(Slot.Collection);
+	}
 
 	Staging.Bounds = FBox(ForceInit);
 	Staging.Path = FSoftObjectPath();
 	ResetEditorContributions();
 }
 
+UPCGExAssetCollection* FPCGExPCGDataAssetCollectionEntry::FindEmbeddedCollection(const FName SlotId) const
+{
+	const FPCGExExportCollectionSlot* Slot = PCGExExportSlots::Find(EmbeddedSlots, SlotId);
+	return Slot ? Slot->Collection.Get() : nullptr;
+}
+
+bool FPCGExPCGDataAssetCollectionEntry::OnHostPostLoad(UPCGExAssetCollection* Host)
+{
+	bool bRewritten = FPCGExAssetCollectionEntry::OnHostPostLoad(Host);
+
+	// Fixed per-entry actor storage -> the "Actors" embedded slot. An already-populated slot wins.
+	if (EmbeddedActorCollection_DEPRECATED || !ExternalActorCollection_DEPRECATED.IsNull())
+	{
+		FPCGExExportCollectionSlot& Slot = PCGExExportSlots::FindOrAdd(EmbeddedSlots, PCGExLevelExport::Slots::Actors);
+		if (!Slot.Collection)
+		{
+			Slot.Collection = EmbeddedActorCollection_DEPRECATED;
+		}
+		if (Slot.External.IsNull())
+		{
+			Slot.External = TSoftObjectPtr<UPCGExAssetCollection>(ExternalActorCollection_DEPRECATED.ToSoftObjectPath());
+		}
+		EmbeddedActorCollection_DEPRECATED = nullptr;
+		ExternalActorCollection_DEPRECATED.Reset();
+		bRewritten = true;
+	}
+
+#if WITH_EDITORONLY_DATA
+	// Fixed mesh/level captures -> keyed captures. Migrated, never dropped: a partial rebuild after the
+	// upgrade recompacts from THESE, and a missing capture would shrink the shared collection and stale
+	// every sibling's hashes. Level picks were identity ints, which is exactly PackLocalPick(local, -1).
+	if (!EditorMeshContributions_DEPRECATED.IsEmpty() || !EditorLocalPicks_DEPRECATED.IsEmpty())
+	{
+		FPCGExExportSlotCapture& Capture = PCGExExportSlots::FindOrAdd(Captures, PCGExLevelExport::Slots::Meshes);
+		if (Capture.Entries.IsEmpty() && Capture.LocalPicks.IsEmpty())
+		{
+			Capture.Entries.Reserve(EditorMeshContributions_DEPRECATED.Num());
+			for (const FPCGExMeshCollectionEntry& Entry : EditorMeshContributions_DEPRECATED)
+			{
+				Capture.Entries.AddDefaulted_GetRef().InitializeAs<FPCGExMeshCollectionEntry>(Entry);
+			}
+			Capture.LocalPicks = MoveTemp(EditorLocalPicks_DEPRECATED);
+		}
+		EditorMeshContributions_DEPRECATED.Reset();
+		EditorLocalPicks_DEPRECATED.Reset();
+		bRewritten = true;
+	}
+
+	if (!EditorLevelContributions_DEPRECATED.IsEmpty() || !EditorLevelLocalPicks_DEPRECATED.IsEmpty())
+	{
+		FPCGExExportSlotCapture& Capture = PCGExExportSlots::FindOrAdd(Captures, PCGExLevelExport::Slots::Levels);
+		if (Capture.Entries.IsEmpty() && Capture.LocalPicks.IsEmpty())
+		{
+			Capture.Entries.Reserve(EditorLevelContributions_DEPRECATED.Num());
+			for (const FPCGExLevelCollectionEntry& Entry : EditorLevelContributions_DEPRECATED)
+			{
+				Capture.Entries.AddDefaulted_GetRef().InitializeAs<FPCGExLevelCollectionEntry>(Entry);
+			}
+			Capture.LocalPicks = MoveTemp(EditorLevelLocalPicks_DEPRECATED);
+		}
+		EditorLevelContributions_DEPRECATED.Reset();
+		EditorLevelLocalPicks_DEPRECATED.Reset();
+		bRewritten = true;
+	}
+#endif
+
+	return bRewritten;
+}
+
 // Shared by the Level and Actor sources once their world is loaded and transform-current.
 //
-// Routes through the 3-arg exporter API so EditorMeshContributions / EditorLocalPicks +
-// EditorLevelContributions / EditorLevelLocalPicks are captured directly into the entry's
-// UPROPERTY storage. Tag_EntryIdx hashes (Meshes + Levels pins) and the CollectionMap pin are
-// NOT written here -- those are produced by the parent collection's CompactSharedMesh /
-// CompactSharedLevel / RebuildCollectionMaps, which see every entry's contributions and
-// resolve final shared indices.
+// Routes through the 3-arg exporter API so per-slot captures land directly in the entry's UPROPERTY
+// storage and per-entry slot collections are rebuilt in place. Shared-slot Tag_EntryIdx hashes and the
+// CollectionMap pin are NOT written here -- those are produced by the host's CompactSharedFor /
+// RebuildCollectionMapsFor, which see every entry's captures and resolve final shared indices.
 bool FPCGExPCGDataAssetCollectionEntry::ExportFromSource(const UPCGExAssetCollection* OwningCollection, const FPCGExLevelExportSource& ExportSource)
 {
 	// Always recreate ExportedDataAsset fresh. Reusing + resetting TaggedData leaves orphaned
@@ -206,37 +287,46 @@ bool FPCGExPCGDataAssetCollectionEntry::ExportFromSource(const UPCGExAssetCollec
 		Exporter = FallbackExporter;
 	}
 
-	// Wire the export context to write directly into the entry's UPROPERTY storage --
-	// no copy at the API boundary. Only available in editor builds; shipping builds run
-	// the exporter without capturing contributions (the shared collections are already
-	// baked into the per-entry ExportedDataAsset hashes at cook time).
+	// Wire the export context to write directly into the entry's UPROPERTY storage -- no copy at the
+	// API boundary. Captures exist in editor builds only; shipping builds run the exporter without
+	// capturing (the shared collections are already baked into the per-entry hashes at cook time).
 	FPCGExLevelExportContext ExportContext;
-	// Reset the capture buffers so a failed export doesn't leave stale data from a prior
-	// rebuild contributing to CompactSharedMesh / CompactSharedLevel.
+	// Reset the capture buffers so a failed export doesn't leave stale data from a prior rebuild
+	// contributing to the shared compaction.
 	ResetEditorContributions();
 #if WITH_EDITORONLY_DATA
-	ExportContext.MeshContributions = &EditorMeshContributions;
-	ExportContext.MeshInheritedDefaults = &EditorMeshInheritedDefaults;
-	ExportContext.MeshLocalPicks = &EditorLocalPicks;
-	ExportContext.LevelContributions = &EditorLevelContributions;
-	ExportContext.LevelLocalPicks = &EditorLevelLocalPicks;
+	ExportContext.Captures = &Captures;
 #endif
-	// The previous actor collection is the exporter's working buffer -- its CollectionGUID
-	// and EntryIds are bound by external references (variants). Cold external sessions load
-	// the externalized asset back. The entry ref stays assigned during export so the object
-	// stays GC-reachable.
-	if (!EmbeddedActorCollection && !ExternalActorCollection.IsNull())
+	ExportContext.CaptureOuter = const_cast<UPCGExAssetCollection*>(OwningCollection);
+
+	// The previous per-entry collections are the exporter's working buffers -- their CollectionGUIDs
+	// and EntryIds are bound by external references (variants). Cold external sessions load the
+	// externalized assets back. The slot refs stay assigned during export so the objects stay
+	// GC-reachable.
+	for (FPCGExExportCollectionSlot& Slot : EmbeddedSlots)
 	{
-		PCGExHelpers::LoadBlocking_AnyThreadTpl(ExternalActorCollection);
-		EmbeddedActorCollection = ExternalActorCollection.Get();
+		if (!Slot.Collection && !Slot.External.IsNull())
+		{
+			PCGExHelpers::LoadBlocking_AnyThreadTpl(Slot.External);
+			Slot.Collection = Slot.External.Get();
+		}
 	}
-	ExportContext.PreviousActorCollection = EmbeddedActorCollection;
-	ExportContext.ActorCollectionOut = &EmbeddedActorCollection;
+	ExportContext.EmbeddedSlots = &EmbeddedSlots;
 
 	const bool bSuccess = Exporter->ExportLevelData(ExportSource, ExportedDataAsset, ExportContext);
 
 	if (bSuccess)
 	{
+		// A slot the exporter did not rebuild this time (no content for it anymore) still points at an
+		// object that was retired with the previous exported asset -- drop it.
+		for (FPCGExExportCollectionSlot& Slot : EmbeddedSlots)
+		{
+			if (Slot.Collection && !Slot.Collection->IsIn(ExportedDataAsset))
+			{
+				Slot.Collection = nullptr;
+			}
+		}
+
 		Staging.Path = FSoftObjectPath(ExportedDataAsset);
 		Staging.Bounds = PCGExPCGDataAssetCollectionInternal::ComputeBoundsFromAsset(ExportedDataAsset);
 
@@ -259,9 +349,12 @@ bool FPCGExPCGDataAssetCollectionEntry::ExportFromSource(const UPCGExAssetCollec
 		Staging.Path = FSoftObjectPath();
 		Staging.Bounds = FBox(ForceInit);
 
-		// Failed exports return before ActorCollectionOut is assigned; the previous
-		// collection's outer chain was just retired -- never serialize it.
-		EmbeddedActorCollection = nullptr;
+		// Failed exports return before any slot is rebuilt; the previous collections' outer chain was
+		// just retired -- never serialize them.
+		for (FPCGExExportCollectionSlot& Slot : EmbeddedSlots)
+		{
+			Slot.Collection = nullptr;
+		}
 		ResetEditorContributions();
 	}
 
@@ -410,7 +503,10 @@ void FPCGExPCGDataAssetCollectionEntry::EDITOR_Sanitize()
 	if (Source != EPCGExDataAssetEntrySource::Level && Source != EPCGExDataAssetEntrySource::Actor)
 	{
 		ExportedDataAsset = nullptr;
-		EmbeddedActorCollection = nullptr;
+		for (FPCGExExportCollectionSlot& Slot : EmbeddedSlots)
+		{
+			Slot.Collection = nullptr;
+		}
 		ResetEditorContributions();
 	}
 }
@@ -508,7 +604,7 @@ FSoftObjectPath FPCGExPCGDataAssetCollectionEntry::EDITOR_GetActivationAssetPath
 
 namespace PCGExSharedCompact
 {
-	static UPCGBasePointData* FindPointDataByPin(UPCGDataAsset* Asset, FName PinName)
+	UPCGBasePointData* FindPointDataByPin(UPCGDataAsset* Asset, FName PinName)
 	{
 		if (!Asset)
 		{
@@ -530,339 +626,102 @@ namespace PCGExSharedCompact
 	// ExternalizeUObject + Internalize live in Helpers/PCGExCollectionExternalization.h now
 	// (shared with the Valency bonding-rules externalization). See that header for contracts.
 
-	// --- Mesh identity ---
-	// Identity hash deliberately omits Weight/Tags/Category/PropertyOverrides -- Weight
-	// accumulates from contributors, the rest are user-owned on the shared entry.
-	// Descriptor fields are not hashed (large structs); ContentEquals resolves collisions.
-	static uint32 MeshContentHash(const FPCGExMeshCollectionEntry& E)
-	{
-		uint32 H = GetTypeHash(E.StaticMesh.ToSoftObjectPath());
-		H = HashCombine(H, GetTypeHash(static_cast<uint8>(E.MaterialVariants)));
-		H = HashCombine(H, GetTypeHash(E.SlotIndex));
-		H = HashCombine(H, GetTypeHash(static_cast<uint8>(E.DescriptorSource)));
-
-		H = HashCombine(H, GetTypeHash(E.MaterialOverrideVariants.Num()));
-		for (const FPCGExMaterialOverrideSingleEntry& S : E.MaterialOverrideVariants)
-		{
-			H = HashCombine(H, GetTypeHash(S.Weight));
-			H = HashCombine(H, GetTypeHash(S.Material.ToSoftObjectPath()));
-		}
-
-		H = HashCombine(H, GetTypeHash(E.MaterialOverrideVariantsList.Num()));
-		for (const FPCGExMaterialOverrideCollection& V : E.MaterialOverrideVariantsList)
-		{
-			H = HashCombine(H, GetTypeHash(V.Weight));
-			H = HashCombine(H, GetTypeHash(V.Overrides.Num()));
-			for (const FPCGExMaterialOverrideEntry& O : V.Overrides)
-			{
-				H = HashCombine(H, GetTypeHash(O.SlotIndex));
-				H = HashCombine(H, GetTypeHash(O.Material.ToSoftObjectPath()));
-			}
-		}
-
-		// Property-component identity. Zero (no source component) hashes as zero, so entries
-		// without a property collection still aggregate alongside each other -- only entries
-		// that actually authored distinct property data split into separate buckets.
-		H = HashCombine(H, E.PropertyComponentHash);
-
-		return H;
-	}
-
-	static bool MaterialOverrideEquals(const FPCGExMaterialOverrideSingleEntry& A, const FPCGExMaterialOverrideSingleEntry& B)
-	{
-		return A.Weight == B.Weight && A.Material.ToSoftObjectPath() == B.Material.ToSoftObjectPath();
-	}
-
-	static bool MaterialOverrideEquals(const FPCGExMaterialOverrideEntry& A, const FPCGExMaterialOverrideEntry& B)
-	{
-		return A.SlotIndex == B.SlotIndex && A.Material.ToSoftObjectPath() == B.Material.ToSoftObjectPath();
-	}
-
-	static bool MaterialOverrideEquals(const FPCGExMaterialOverrideCollection& A, const FPCGExMaterialOverrideCollection& B)
-	{
-		if (A.Weight != B.Weight)
-		{
-			return false;
-		}
-		if (A.Overrides.Num() != B.Overrides.Num())
-		{
-			return false;
-		}
-		for (int32 i = 0; i < A.Overrides.Num(); i++)
-		{
-			if (!MaterialOverrideEquals(A.Overrides[i], B.Overrides[i]))
-			{
-				return false;
-			}
-		}
-		return true;
-	}
-
-	static bool MeshContentEquals(const FPCGExMeshCollectionEntry& A, const FPCGExMeshCollectionEntry& B)
-	{
-		if (A.StaticMesh.ToSoftObjectPath() != B.StaticMesh.ToSoftObjectPath())
-		{
-			return false;
-		}
-		if (A.MaterialVariants != B.MaterialVariants)
-		{
-			return false;
-		}
-		if (A.SlotIndex != B.SlotIndex)
-		{
-			return false;
-		}
-		if (A.DescriptorSource != B.DescriptorSource)
-		{
-			return false;
-		}
-
-		if (A.MaterialOverrideVariants.Num() != B.MaterialOverrideVariants.Num())
-		{
-			return false;
-		}
-		for (int32 i = 0; i < A.MaterialOverrideVariants.Num(); i++)
-		{
-			if (!MaterialOverrideEquals(A.MaterialOverrideVariants[i], B.MaterialOverrideVariants[i]))
-			{
-				return false;
-			}
-		}
-
-		if (A.MaterialOverrideVariantsList.Num() != B.MaterialOverrideVariantsList.Num())
-		{
-			return false;
-		}
-		for (int32 i = 0; i < A.MaterialOverrideVariantsList.Num(); i++)
-		{
-			if (!MaterialOverrideEquals(A.MaterialOverrideVariantsList[i], B.MaterialOverrideVariantsList[i]))
-			{
-				return false;
-			}
-		}
-
-		if (!FSoftISMComponentDescriptor::StaticStruct()->CompareScriptStruct(&A.ISMDescriptor, &B.ISMDescriptor, 0))
-		{
-			return false;
-		}
-		if (!FPCGExStaticMeshComponentDescriptor::StaticStruct()->CompareScriptStruct(&A.SMDescriptor, &B.SMDescriptor, 0))
-		{
-			return false;
-		}
-
-		// Property-component identity must match for two entries to dedup. Crucial when
-		// otherwise-identical mesh actors carry distinct property values: we want them in
-		// separate shared entries so their per-instance PropertyOverrides survive.
-		if (A.PropertyComponentHash != B.PropertyComponentHash)
-		{
-			return false;
-		}
-
-		return true;
-	}
-
 #if WITH_EDITOR
-	// Policies + CompactShared reference Editor* fields on FPCGExPCGDataAssetCollectionEntry
-	// which are themselves WITH_EDITORONLY_DATA. Their callers (CompactSharedMesh /
-	// CompactSharedLevel) are body-guarded the same way.
-	//
-	// SortKey implementations live in Helpers/PCGExCollectionSortKeys.{h,cpp} as free
-	// functions so they're directly testable from PCGExtendedToolkitTest. FArchiveBlake3
-	// (the process-stable Blake3 archive that backs the descriptor digest) is exposed in
-	// Helpers/PCGExArchiveBlake3.h. The full SortKey contract -- process-stable, fully
-	// discriminating, leading-field stable on mesh path -- is documented on the header
-	// declarations.
-
-	// --- Policy structs supplying entry-specific knowledge to CompactShared<>. ---
-	struct FMeshPolicy
+	const FPCGExExportSlotCapture* FindCapture(const FPCGExPCGDataAssetCollectionEntry& Entry, const FName SlotId)
 	{
-		using EntryType = FPCGExMeshCollectionEntry;
-		using CollectionType = UPCGExMeshCollection;
+		return PCGExExportSlots::Find(Entry.Captures, SlotId);
+	}
 
-		static FName PinName()
-		{
-			return PCGExCollections::Labels::MeshesPin;
-		}
-
-		static uint32 Hash(const FPCGExMeshCollectionEntry& E)
-		{
-			return MeshContentHash(E);
-		}
-
-		static bool Equals(const FPCGExMeshCollectionEntry& A, const FPCGExMeshCollectionEntry& B)
-		{
-			return MeshContentEquals(A, B);
-		}
-
-		static FString SortKey(const FPCGExMeshCollectionEntry& E)
-		{
-			return MeshSortKey(E);
-		}
-
-		// Loose identity for EntryId preservation -- the binding survives variant/descriptor tweaks.
-		static FSoftObjectPath PrimaryPath(const FPCGExMeshCollectionEntry& E)
-		{
-			return E.StaticMesh.ToSoftObjectPath();
-		}
-
-		static const TArray<FPCGExMeshCollectionEntry>& Contributions(const FPCGExPCGDataAssetCollectionEntry& E)
-		{
-			return E.EditorMeshContributions;
-		}
-
-		static const TArray<FInstancedStruct>& InheritedDefaults(const FPCGExPCGDataAssetCollectionEntry& E)
-		{
-			return E.EditorMeshInheritedDefaults;
-		}
-
-		static const TArray<int32>& LocalPicks(const FPCGExPCGDataAssetCollectionEntry& E)
-		{
-			return E.EditorLocalPicks;
-		}
-
-		static int16 UnpackSec(int32 Packed, int32& OutLocal)
-		{
-			int16 Sec;
-			FPCGExLevelExportContext::UnpackLocalPick(Packed, OutLocal, Sec);
-			return Sec;
-		}
-	};
-
-	struct FLevelPolicy
-	{
-		using EntryType = FPCGExLevelCollectionEntry;
-		using CollectionType = UPCGExLevelCollection;
-
-		static FName PinName()
-		{
-			return PCGExCollections::Labels::LevelsPin;
-		}
-
-		static uint32 Hash(const FPCGExLevelCollectionEntry& E)
-		{
-			return GetTypeHash(E.Level.ToSoftObjectPath());
-		}
-
-		static bool Equals(const FPCGExLevelCollectionEntry& A, const FPCGExLevelCollectionEntry& B)
-		{
-			return A.Level.ToSoftObjectPath() == B.Level.ToSoftObjectPath();
-		}
-
-		static FString SortKey(const FPCGExLevelCollectionEntry& E)
-		{
-			return LevelSortKey(E);
-		}
-
-		// Path IS the level identity; present to keep the templated preservation body uniform.
-		static FSoftObjectPath PrimaryPath(const FPCGExLevelCollectionEntry& E)
-		{
-			return E.Level.ToSoftObjectPath();
-		}
-
-		static const TArray<FPCGExLevelCollectionEntry>& Contributions(const FPCGExPCGDataAssetCollectionEntry& E)
-		{
-			return E.EditorLevelContributions;
-		}
-
-		// Level entries don't carry property-component data, so there's no inherited-defaults
-		// view to aggregate. Returning an empty static makes the templated CompactShared body
-		// produce an empty aggregate that flows through to RefreshCollectionPropertiesFromEntries
-		// as the "no opinion, fall through to contributors" signal.
-		static const TArray<FInstancedStruct>& InheritedDefaults(const FPCGExPCGDataAssetCollectionEntry& /*E*/)
-		{
-			static const TArray<FInstancedStruct> Empty;
-			return Empty;
-		}
-
-		static const TArray<int32>& LocalPicks(const FPCGExPCGDataAssetCollectionEntry& E)
-		{
-			return E.EditorLevelLocalPicks;
-		}
-
-		static int16 UnpackSec(int32 Packed, int32& OutLocal)
-		{
-			OutLocal = Packed;
-			return -1;
-		}
-	};
-
-	// Merge every entry's local contributions into one deduplicated shared collection
-	// (identity via TPolicy::Hash + TPolicy::Equals), then rewrite Tag_EntryIdx on the
-	// policy's pin against the resulting shared indices. Tags/Category/PropertyOverrides
-	// on existing shared entries are preserved across rebuilds when identity survives.
-	// Deterministic ordering: by content-derived SortKey ascending -- stable across cold cooks
-	// and editor restarts (does NOT depend on the per-process FName comparison-index hash).
-	template <typename TPolicy>
-	static void CompactShared(
+	// Merge every entry's captured contributions for one slot into its deduplicated shared collection
+	// (identity via the policy's Hash + Equals), then rewrite Tag_EntryIdx on the slot's pin against the
+	// resulting shared indices. Tags/Category on existing shared entries are preserved across rebuilds
+	// when identity survives. Deterministic ordering: by content-derived SortKey ascending -- stable
+	// across cold cooks and editor restarts (does NOT depend on the per-process FName hash).
+	void CompactSharedSlot(
 		UObject* Outer,
 		const TArray<FPCGExPCGDataAssetCollectionEntry*>& Entries,
-		TObjectPtr<typename TPolicy::CollectionType>& SharedCollectionRef,
-		TSoftObjectPtr<typename TPolicy::CollectionType>* ExternalFallback)
+		const FPCGExExportSlotDesc& Desc,
+		const IPCGExExportSlotPolicy& Policy,
+		FPCGExExportCollectionSlot& Slot,
+		const bool bExternalActive)
 	{
-		using TEntry = TPolicy::EntryType;
-		using TCollection = TPolicy::CollectionType;
+		const UScriptStruct* EntryStruct = Desc.EntryStruct;
 
 		// Skip everything when there's nothing to merge AND no existing shared state to clear.
 		// Avoids a synchronous external-asset load on unrelated edits (e.g. weight tweak on a
-		// non-level entry) when no entry contributes to this policy.
+		// non-level entry) when no entry contributes to this slot.
 		bool bHasContributions = false;
 		for (const FPCGExPCGDataAssetCollectionEntry* E : Entries)
 		{
-			if (TPolicy::Contributions(*E).Num() > 0)
+			const FPCGExExportSlotCapture* Capture = FindCapture(*E, Desc.SlotId);
+			if (Capture && Capture->Entries.Num() > 0)
 			{
 				bHasContributions = true;
 				break;
 			}
 		}
-		if (!bHasContributions && !SharedCollectionRef
-			&& (!ExternalFallback || ExternalFallback->IsNull()))
+		if (!bHasContributions && !Slot.Collection && (!bExternalActive || Slot.External.IsNull()))
 		{
 			return;
 		}
 
 		// External mode: if the in-memory ref was nulled by a prior externalization, pull the
 		// asset back into the collection package as the working buffer so the preserved-fields
-		// pass below sees the previous entries' user edits (Tags/Category/PropertyOverrides).
-		// The next ExternalizeSharedAndActorCollections will overwrite the same external uasset.
-		if (!SharedCollectionRef && ExternalFallback && !ExternalFallback->IsNull())
+		// pass below sees the previous entries' user edits (Tags/Category). The next
+		// ExternalizeSlotCollectionsFor will overwrite the same external uasset.
+		if (!Slot.Collection && bExternalActive && !Slot.External.IsNull())
 		{
-			if (TCollection* Loaded = ExternalFallback->LoadSynchronous())
+			if (UPCGExAssetCollection* Loaded = Slot.External.LoadSynchronous())
 			{
 				Loaded->Rename(nullptr, Outer, REN_DontCreateRedirectors | REN_NonTransactional);
-				SharedCollectionRef = Loaded;
+				Slot.Collection = Loaded;
 			}
+		}
+
+		// A slot whose registered class changed cannot keep the object (its rows are another struct).
+		if (Slot.Collection && Slot.Collection->GetClass() != Desc.CollectionClass)
+		{
+			UE_LOG(LogPCGEx, Warning, TEXT("Shared slot '%s' held a '%s' but the slot is now registered as '%s'; rebuilding from scratch (external references to it are lost)."),
+			       *Desc.SlotId.ToString(), *Slot.Collection->GetClass()->GetName(), *Desc.CollectionClass->GetName());
+			Slot.Collection->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors | REN_NonTransactional);
+			Slot.Collection = nullptr;
 		}
 
 		// Reuse the same UObject across calls so its CollectionGUID -- baked into every
 		// per-entry Tag_EntryIdx -- stays stable. Replacing it would invalidate on-disk hashes.
-		if (!SharedCollectionRef)
+		if (!Slot.Collection)
 		{
-			SharedCollectionRef = NewObject<TCollection>(Outer);
+			Slot.Collection = NewObject<UPCGExAssetCollection>(Outer, Desc.CollectionClass);
 		}
+		UPCGExAssetCollection* SharedCollection = Slot.Collection;
 
 		struct FPreserved
 		{
-			TEntry Identity;
+			FInstancedStruct Identity;
 			TSet<FName> Tags;
 			FName Category = NAME_None;
-			FPCGExPropertyOverrides PropertyOverrides;
+			int32 EntryId = 0;
 			bool bEntryIdConsumed = false; // exact-matched by a merged group; keeps its id out of the loose-fallback bank
 		};
 		TMap<uint32, TArray<FPreserved>> PreservedByHash;
-		for (const TEntry& E : SharedCollectionRef->Entries)
+		SharedCollection->ForEachEntry([&](const FPCGExAssetCollectionEntry* E, int32)
 		{
-			const uint32 H = TPolicy::Hash(E);
+			if (!E)
+			{
+				return;
+			}
+			const uint32 H = Policy.Hash(*E);
 			FPreserved& P = PreservedByHash.FindOrAdd(H).AddDefaulted_GetRef();
-			P.Identity = E;
-			P.Tags = E.Tags;
-			P.Category = E.Category;
-			P.PropertyOverrides = E.PropertyOverrides;
-		}
+			P.Identity.InitializeAs(EntryStruct, reinterpret_cast<const uint8*>(E));
+			P.Tags = E->Tags;
+			P.Category = E->Category;
+			P.EntryId = E->EntryId;
+		});
 
 		struct FGroup
 		{
 			uint32 Hash = 0;
-			const TEntry* Representative = nullptr;
+			const FPCGExAssetCollectionEntry* Representative = nullptr;
 			FString SortKey;
 			TArray<TPair<int32, int32>> Contributors; // (entryIdx, localContribIdx)
 			int32 WeightSum = 0;
@@ -871,17 +730,27 @@ namespace PCGExSharedCompact
 
 		for (int32 EntryIdx = 0; EntryIdx < Entries.Num(); EntryIdx++)
 		{
-			const TArray<TEntry>& Contribs = TPolicy::Contributions(*Entries[EntryIdx]);
-			for (int32 LocalIdx = 0; LocalIdx < Contribs.Num(); LocalIdx++)
+			const FPCGExExportSlotCapture* Capture = FindCapture(*Entries[EntryIdx], Desc.SlotId);
+			if (!Capture)
 			{
-				const TEntry& Contrib = Contribs[LocalIdx];
-				const uint32 H = TPolicy::Hash(Contrib);
+				continue;
+			}
+			for (int32 LocalIdx = 0; LocalIdx < Capture->Entries.Num(); LocalIdx++)
+			{
+				const FInstancedStruct& Instanced = Capture->Entries[LocalIdx];
+				if (Instanced.GetScriptStruct() != EntryStruct)
+				{
+					// A capture written by a different registration of this slot id; it cannot be merged.
+					continue;
+				}
+				const FPCGExAssetCollectionEntry& Contrib = *Instanced.GetPtr<FPCGExAssetCollectionEntry>();
+				const uint32 H = Policy.Hash(Contrib);
 
 				TArray<FGroup>& Bucket = HashBuckets.FindOrAdd(H);
 				FGroup* Match = nullptr;
 				for (FGroup& G : Bucket)
 				{
-					if (TPolicy::Equals(*G.Representative, Contrib))
+					if (Policy.Equals(*G.Representative, Contrib))
 					{
 						Match = &G;
 						break;
@@ -892,7 +761,7 @@ namespace PCGExSharedCompact
 					FGroup NewGroup;
 					NewGroup.Hash = H;
 					NewGroup.Representative = &Contrib;
-					NewGroup.SortKey = TPolicy::SortKey(Contrib);
+					NewGroup.SortKey = Policy.SortKey(Contrib);
 					Match = &Bucket.Add_GetRef(MoveTemp(NewGroup));
 				}
 				Match->Contributors.Emplace(EntryIdx, LocalIdx);
@@ -908,18 +777,16 @@ namespace PCGExSharedCompact
 				AllGroups.Add(MoveTemp(G));
 			}
 		}
-		// Order purely by the content-derived, process-stable SortKey. FGroup::Hash is NOT used
-		// here: it comes from TPolicy::Hash -> GetTypeHash(FSoftObjectPath) -> GetTypeHash(FName),
-		// which is the per-process FName comparison index and reshuffles across sessions/cooks.
-		// TPolicy::SortKey fully discriminates every distinct group (see FMeshPolicy::SortKey), so
-		// no two groups share a key and there is no tie-break to fall back on. Hash is retained
-		// only as an in-process bucket key for grouping/preservation above.
+		// Order purely by the content-derived, process-stable SortKey. FGroup::Hash is NOT used here:
+		// GetTypeHash(FSoftObjectPath) rides the per-process FName comparison index and reshuffles across
+		// sessions/cooks. The policy's SortKey fully discriminates every distinct group, so there is no
+		// tie-break to fall back on. Hash is retained only as an in-process bucket key.
 		AllGroups.Sort([](const FGroup& A, const FGroup& B)
 		{
 			return A.SortKey < B.SortKey;
 		});
 
-		TArray<TEntry> MergedEntries;
+		TArray<FInstancedStruct> MergedEntries;
 		MergedEntries.Reserve(AllGroups.Num());
 
 		TArray<TArray<int32>> LocalToSharedByEntry;
@@ -927,13 +794,16 @@ namespace PCGExSharedCompact
 		for (int32 i = 0; i < Entries.Num(); i++)
 		{
 			// -1 = no shared mapping; rewrite pass leaves the hash unwritten.
-			LocalToSharedByEntry[i].Init(-1, TPolicy::Contributions(*Entries[i]).Num());
+			const FPCGExExportSlotCapture* Capture = FindCapture(*Entries[i], Desc.SlotId);
+			LocalToSharedByEntry[i].Init(-1, Capture ? Capture->Entries.Num() : 0);
 		}
 
 		for (int32 SharedIdx = 0; SharedIdx < AllGroups.Num(); SharedIdx++)
 		{
 			const FGroup& G = AllGroups[SharedIdx];
-			TEntry Merged = *G.Representative;
+			FInstancedStruct& MergedInstanced = MergedEntries.AddDefaulted_GetRef();
+			MergedInstanced.InitializeAs(EntryStruct, reinterpret_cast<const uint8*>(G.Representative));
+			FPCGExAssetCollectionEntry& Merged = *MergedInstanced.GetMutablePtr<FPCGExAssetCollectionEntry>();
 			Merged.Weight = FMath::Max(1, G.WeightSum);
 
 			// Contribution snapshots carry their SOURCE's id, not this collection's; zero is
@@ -944,24 +814,21 @@ namespace PCGExSharedCompact
 			{
 				for (FPreserved& P : *Bucket)
 				{
-					if (TPolicy::Equals(P.Identity, *G.Representative))
+					if (Policy.Equals(*P.Identity.GetPtr<FPCGExAssetCollectionEntry>(), *G.Representative))
 					{
 						Merged.Tags = P.Tags;
 						Merged.Category = P.Category;
 						// PropertyOverrides is intentionally NOT preserved: it's derived from
-						// per-export actor contributions, not user-authored on the shared
-						// collection. Preserving it perpetuates stale values across re-exports.
+						// per-export contributions, not user-authored on the shared collection.
 						// Tags/Category ARE user-authored and have no per-export contributor.
 
 						// EntryId IS preserved: external references bind by id.
-						Merged.EntryId = P.Identity.EntryId;
+						Merged.EntryId = P.EntryId;
 						P.bEntryIdConsumed = true;
 						break;
 					}
 				}
 			}
-
-			MergedEntries.Add(MoveTemp(Merged));
 
 			for (const TPair<int32, int32>& C : G.Contributors)
 			{
@@ -980,64 +847,78 @@ namespace PCGExSharedCompact
 				{
 					if (!P.bEntryIdConsumed)
 					{
-						FallbackIds.Deposit(0, GetTypeHash(TPolicy::PrimaryPath(P.Identity)), P.Identity.EntryId);
+						FallbackIds.Deposit(0, GetTypeHash(Policy.PrimaryPath(*P.Identity.GetPtr<FPCGExAssetCollectionEntry>())), P.EntryId);
 					}
 				}
 			}
 
-			for (TEntry& Merged : MergedEntries)
+			for (FInstancedStruct& MergedInstanced : MergedEntries)
 			{
+				FPCGExAssetCollectionEntry& Merged = *MergedInstanced.GetMutablePtr<FPCGExAssetCollectionEntry>();
 				if (Merged.EntryId == 0)
 				{
-					Merged.EntryId = FallbackIds.ClaimLoose(GetTypeHash(TPolicy::PrimaryPath(Merged)));
+					Merged.EntryId = FallbackIds.ClaimLoose(GetTypeHash(Policy.PrimaryPath(Merged)));
 				}
 			}
 		}
 
-		SharedCollectionRef->Entries = MoveTemp(MergedEntries);
+		// Previous rows are overwritten wholesale; retire the subobjects they owned first, then write the
+		// merged rows with their own duplicates (a capture keeps its originals under the host).
+		SharedCollection->ForEachEntry([EntryStruct](FPCGExAssetCollectionEntry* E, int32)
+		{
+			if (E)
+			{
+				PCGExCollectionHelpers::RetireInstancedSubobjects(EntryStruct, E);
+			}
+		});
+		SharedCollection->InitNumEntries(MergedEntries.Num());
+		for (int32 i = 0; i < MergedEntries.Num(); i++)
+		{
+			FPCGExAssetCollectionEntry* Dst = SharedCollection->GetMutableEntryRaw(i);
+			EntryStruct->CopyScriptStruct(Dst, MergedEntries[i].GetMemory());
+			PCGExCollectionHelpers::DuplicateInstancedSubobjects(EntryStruct, Dst, SharedCollection);
+		}
 
 		// Aggregate the per-export "inherited defaults" views across every contributing entry.
-		// Each entry's view is the actor-class CDO/asset-fallback aggregate computed by the
-		// exporter (FPCGExLevelExportContext::MeshInheritedDefaults). Per property name, only
-		// values unanimously agreed across entries survive; disagreements drop out and fall
-		// through to per-entry contributors at merge time. Level-policy returns an empty array
-		// so this aggregate is naturally empty for the level path.
+		// Per property name, only values unanimously agreed across entries survive; disagreements
+		// drop out and fall through to per-entry contributors at merge time. Slots that capture no
+		// view produce an empty aggregate.
 		TArray<TConstArrayView<FInstancedStruct>> InheritedViews;
 		InheritedViews.Reserve(Entries.Num());
 		for (const FPCGExPCGDataAssetCollectionEntry* E : Entries)
 		{
-			InheritedViews.Emplace(TPolicy::InheritedDefaults(*E));
+			if (const FPCGExExportSlotCapture* Capture = FindCapture(*E, Desc.SlotId))
+			{
+				InheritedViews.Emplace(Capture->InheritedDefaults);
+			}
 		}
 		TArray<FInstancedStruct> InheritedDefaultsAggregate = PCGExProperties::AggregateAgreedValuesByName(InheritedViews);
 
 		// Rebuild CollectionProperties from the union of every merged entry's enabled
-		// PropertyOverrides. Mesh entries authored by UPCGExDefaultLevelDataExporter carry
-		// their source actor's property-component values in their overrides; this collapses
-		// them into a canonical schema on the shared collection and re-syncs the per-entry
-		// overrides against it. No-op for collection types whose entries don't carry
-		// property data (e.g. UPCGExLevelCollection in current usage).
-		SharedCollectionRef->RefreshCollectionPropertiesFromEntries(
+		// PropertyOverrides, and re-sync the per-entry overrides against it. No-op for
+		// collection types whose entries don't carry property data.
+		SharedCollection->RefreshCollectionPropertiesFromEntries(
 			EPCGExSchemaMergePolicy::StrictTypeMatch,
 			InheritedDefaultsAggregate);
 
-		SharedCollectionRef->RebuildStagingData(true);
+		SharedCollection->RebuildStagingData(true);
 
 		// Per-entry Tag_EntryIdx rewrite. CollectionMap is rebuilt separately so it can
-		// register the other shared collection too. Sequential: UPCGMetadata mutation is
-		// not safe on worker threads in editor flow.
+		// register every other slot too. Sequential: UPCGMetadata mutation is not safe on
+		// worker threads in editor flow.
 		PCGExCollections::FPickPacker Packer;
-		Packer.RegisterCollection(SharedCollectionRef);
+		Packer.RegisterCollection(SharedCollection);
 
-		const FName PinName = TPolicy::PinName();
 		for (int32 EntryIdx = 0; EntryIdx < Entries.Num(); EntryIdx++)
 		{
 			FPCGExPCGDataAssetCollectionEntry& Entry = *Entries[EntryIdx];
-			if (!Entry.ExportedDataAsset)
+			const FPCGExExportSlotCapture* Capture = FindCapture(Entry, Desc.SlotId);
+			if (!Entry.ExportedDataAsset || !Capture)
 			{
 				continue;
 			}
 
-			UPCGBasePointData* PD = FindPointDataByPin(Entry.ExportedDataAsset, PinName);
+			UPCGBasePointData* PD = FindPointDataByPin(Entry.ExportedDataAsset, Desc.PinName);
 			if (!PD)
 			{
 				continue;
@@ -1057,7 +938,7 @@ namespace PCGExSharedCompact
 			}
 
 			const TArray<int32>& LocalToShared = LocalToSharedByEntry[EntryIdx];
-			const TArray<int32>& LocalPicks = TPolicy::LocalPicks(Entry);
+			const TArray<int32>& LocalPicks = Capture->LocalPicks;
 			const int32 N = FMath::Min(LocalPicks.Num(), MetaEntries.Num());
 			for (int32 i = 0; i < N; i++)
 			{
@@ -1067,7 +948,12 @@ namespace PCGExSharedCompact
 					continue;
 				}
 				int32 LocalIdx;
-				const int16 Sec = TPolicy::UnpackSec(Packed, LocalIdx);
+				int16 Sec;
+				FPCGExLevelExportContext::UnpackLocalPick(Packed, LocalIdx, Sec);
+				if (!Desc.bSupportsSecondary)
+				{
+					Sec = -1;
+				}
 				if (!LocalToShared.IsValidIndex(LocalIdx))
 				{
 					continue;
@@ -1077,7 +963,7 @@ namespace PCGExSharedCompact
 				{
 					continue;
 				}
-				const uint64 Hash = Packer.GetPickIdx(SharedCollectionRef, static_cast<int16>(SharedIdx), Sec);
+				const uint64 Hash = Packer.GetPickIdx(SharedCollection, static_cast<int16>(SharedIdx), Sec);
 				EntryHashAttr->SetValue(MetaEntries[i], static_cast<int64>(Hash));
 			}
 		}
@@ -1108,6 +994,10 @@ void UPCGExPCGDataAssetCollection::PostLoad()
 	// the state only holds the refs -- same shape as an Omni host.
 	if (MachineryState)
 	{
+		// The state's own PostLoad adopts ITS legacy members; run it first so the slots are settled
+		// before the pre-C1 members below are adopted through the same idempotent helper.
+		MachineryState->ConditionalPostLoad();
+
 		if (bUseExternalAssets_DEPRECATED)
 		{
 			MachineryState->bUseExternalAssets = true;
@@ -1118,26 +1008,14 @@ void UPCGExPCGDataAssetCollection::PostLoad()
 			MachineryState->ExportFolder = ExportFolder_DEPRECATED;
 			ExportFolder_DEPRECATED.Path.Reset();
 		}
-		if (SharedMeshCollection_DEPRECATED)
-		{
-			MachineryState->SharedMeshCollection = SharedMeshCollection_DEPRECATED;
-			SharedMeshCollection_DEPRECATED = nullptr;
-		}
-		if (SharedLevelCollection_DEPRECATED)
-		{
-			MachineryState->SharedLevelCollection = SharedLevelCollection_DEPRECATED;
-			SharedLevelCollection_DEPRECATED = nullptr;
-		}
-		if (!ExternalSharedMeshCollection_DEPRECATED.IsNull())
-		{
-			MachineryState->ExternalSharedMeshCollection = ExternalSharedMeshCollection_DEPRECATED;
-			ExternalSharedMeshCollection_DEPRECATED.Reset();
-		}
-		if (!ExternalSharedLevelCollection_DEPRECATED.IsNull())
-		{
-			MachineryState->ExternalSharedLevelCollection = ExternalSharedLevelCollection_DEPRECATED;
-			ExternalSharedLevelCollection_DEPRECATED.Reset();
-		}
+
+		MachineryState->AdoptLegacySlot(PCGExLevelExport::Slots::Meshes, SharedMeshCollection_DEPRECATED, ExternalSharedMeshCollection_DEPRECATED.ToSoftObjectPath());
+		SharedMeshCollection_DEPRECATED = nullptr;
+		ExternalSharedMeshCollection_DEPRECATED.Reset();
+
+		MachineryState->AdoptLegacySlot(PCGExLevelExport::Slots::Levels, SharedLevelCollection_DEPRECATED, ExternalSharedLevelCollection_DEPRECATED.ToSoftObjectPath());
+		SharedLevelCollection_DEPRECATED = nullptr;
+		ExternalSharedLevelCollection_DEPRECATED.Reset();
 	}
 }
 
@@ -1167,29 +1045,44 @@ FString UPCGExPCGDataAssetCollection::MakeExternalAssetPrefixFor(const UPCGExAss
 	return FString::Printf(TEXT("G_%08X"), Host ? Host->GetCollectionGUID() : 0u);
 }
 
-void UPCGExPCGDataAssetCollection::CompactSharedMeshFor(FPCGExPCGDataAssetMachinery& State)
+void UPCGExPCGDataAssetCollection::CompactSharedFor(FPCGExPCGDataAssetMachinery& State)
 {
-#if WITH_EDITORONLY_DATA
+#if WITH_EDITOR
 	if (!State.IsValid())
 	{
 		return;
 	}
-	PCGExSharedCompact::CompactShared<PCGExSharedCompact::FMeshPolicy>(
-		State.Host, State.Entries, *State.SharedMeshCollection,
-		State.bExternalActive ? State.ExternalSharedMeshCollection : nullptr);
-#endif
-}
 
-void UPCGExPCGDataAssetCollection::CompactSharedLevelFor(FPCGExPCGDataAssetMachinery& State)
-{
-#if WITH_EDITORONLY_DATA
-	if (!State.IsValid())
+	TArray<PCGExLevelExport::FHandlerRegistration> Registrations;
+	PCGExLevelExport::FHandlerRegistry::Get().GetRegistrations(Registrations);
+
+	for (const PCGExLevelExport::FHandlerRegistration& Registration : Registrations)
 	{
-		return;
+		const FPCGExExportSlotDesc& Desc = Registration.Desc;
+		if (Desc.Scope != EPCGExExportSlotScope::Shared || !Registration.Policy)
+		{
+			continue;
+		}
+
+		// No storage is minted for a slot nothing contributes to and nothing held before.
+		bool bHasContributions = false;
+		for (const FPCGExPCGDataAssetCollectionEntry* E : State.Entries)
+		{
+			const FPCGExExportSlotCapture* Capture = PCGExExportSlots::Find(E->Captures, Desc.SlotId);
+			if (Capture && !Capture->Entries.IsEmpty())
+			{
+				bHasContributions = true;
+				break;
+			}
+		}
+		if (!bHasContributions && !PCGExExportSlots::Find(*State.SharedSlots, Desc.SlotId))
+		{
+			continue;
+		}
+
+		FPCGExExportCollectionSlot& Slot = PCGExExportSlots::FindOrAdd(*State.SharedSlots, Desc.SlotId);
+		PCGExSharedCompact::CompactSharedSlot(State.Host, State.Entries, Desc, *Registration.Policy, Slot, State.bExternalActive);
 	}
-	PCGExSharedCompact::CompactShared<PCGExSharedCompact::FLevelPolicy>(
-		State.Host, State.Entries, *State.SharedLevelCollection,
-		State.bExternalActive ? State.ExternalSharedLevelCollection : nullptr);
 #endif
 }
 
@@ -1209,17 +1102,19 @@ void UPCGExPCGDataAssetCollection::RebuildCollectionMapsFor(FPCGExPCGDataAssetMa
 		}
 
 		PCGExCollections::FPickPacker FullPacker;
-		if (*State.SharedMeshCollection)
+		for (const FPCGExExportCollectionSlot& Slot : *State.SharedSlots)
 		{
-			FullPacker.RegisterCollection(*State.SharedMeshCollection);
+			if (Slot.Collection)
+			{
+				FullPacker.RegisterCollection(Slot.Collection);
+			}
 		}
-		if (*State.SharedLevelCollection)
+		for (const FPCGExExportCollectionSlot& Slot : Entry.EmbeddedSlots)
 		{
-			FullPacker.RegisterCollection(*State.SharedLevelCollection);
-		}
-		if (Entry.EmbeddedActorCollection)
-		{
-			FullPacker.RegisterCollection(Entry.EmbeddedActorCollection);
+			if (Slot.Collection)
+			{
+				FullPacker.RegisterCollection(Slot.Collection);
+			}
 		}
 
 		Entry.ExportedDataAsset->Data.TaggedData.RemoveAll([](const FPCGTaggedData& TD)
@@ -1235,7 +1130,7 @@ void UPCGExPCGDataAssetCollection::RebuildCollectionMapsFor(FPCGExPCGDataAssetMa
 	}
 }
 
-void UPCGExPCGDataAssetCollection::ExternalizeSharedAndActorCollectionsFor(FPCGExPCGDataAssetMachinery& State)
+void UPCGExPCGDataAssetCollection::ExternalizeSlotCollectionsFor(FPCGExPCGDataAssetMachinery& State)
 {
 #if WITH_EDITOR
 	if (!State.IsValid() || !State.bExternalActive)
@@ -1245,34 +1140,35 @@ void UPCGExPCGDataAssetCollection::ExternalizeSharedAndActorCollectionsFor(FPCGE
 
 	// Naming uses the collection's GUID for cross-collection uniqueness in a shared export
 	// folder, and is short enough to stay within filesystem path budgets. GUID is stable
-	// across rebuilds -- filenames are reused (P4-friendly overwrites).
+	// across rebuilds -- filenames are reused (P4-friendly overwrites). The slot id is the
+	// suffix, so the built-in slots keep their historical file names.
 	const FString& FolderPath = State.ExportFolderPath;
 	const FString& GuidPrefix = State.ExternalAssetPrefix;
 
-	if (*State.SharedMeshCollection)
+	for (FPCGExExportCollectionSlot& Slot : *State.SharedSlots)
 	{
-		const FString AssetName = GuidPrefix + TEXT("_Meshes");
-		*State.ExternalSharedMeshCollection = PCGExSharedCompact::ExternalizeUObject(*State.SharedMeshCollection, FolderPath / AssetName, AssetName);
-	}
-
-	if (*State.SharedLevelCollection)
-	{
-		const FString AssetName = GuidPrefix + TEXT("_Levels");
-		*State.ExternalSharedLevelCollection = PCGExSharedCompact::ExternalizeUObject(*State.SharedLevelCollection, FolderPath / AssetName, AssetName);
-	}
-
-	// Per-entry actor collections. Done before RebuildCollectionMaps so the soft paths the
-	// packer bakes into the CollectionMap pin already point at the external assets.
-	for (int32 EntryIdx = 0; EntryIdx < State.Entries.Num(); EntryIdx++)
-	{
-		FPCGExPCGDataAssetCollectionEntry& Entry = *State.Entries[EntryIdx];
-		if (!Entry.EmbeddedActorCollection)
+		if (!Slot.Collection)
 		{
 			continue;
 		}
+		const FString AssetName = FString::Printf(TEXT("%s_%s"), *GuidPrefix, *Slot.SlotId.ToString());
+		Slot.External = TSoftObjectPtr<UPCGExAssetCollection>(PCGExSharedCompact::ExternalizeUObject(Slot.Collection, FolderPath / AssetName, AssetName));
+	}
 
-		const FString AssetName = FString::Printf(TEXT("%s_E%03d_Actors"), *GuidPrefix, EntryIdx);
-		Entry.ExternalActorCollection = PCGExSharedCompact::ExternalizeUObject(Entry.EmbeddedActorCollection, FolderPath / AssetName, AssetName);
+	// Per-entry slots. Done before RebuildCollectionMaps so the soft paths the packer bakes into
+	// the CollectionMap pin already point at the external assets.
+	for (int32 EntryIdx = 0; EntryIdx < State.Entries.Num(); EntryIdx++)
+	{
+		FPCGExPCGDataAssetCollectionEntry& Entry = *State.Entries[EntryIdx];
+		for (FPCGExExportCollectionSlot& Slot : Entry.EmbeddedSlots)
+		{
+			if (!Slot.Collection)
+			{
+				continue;
+			}
+			const FString AssetName = FString::Printf(TEXT("%s_E%03d_%s"), *GuidPrefix, EntryIdx, *Slot.SlotId.ToString());
+			Slot.External = TSoftObjectPtr<UPCGExAssetCollection>(PCGExSharedCompact::ExternalizeUObject(Slot.Collection, FolderPath / AssetName, AssetName));
+		}
 	}
 #endif
 }
@@ -1316,18 +1212,23 @@ void UPCGExPCGDataAssetCollection::InternalizeSubobjectsFor(FPCGExPCGDataAssetMa
 	}
 
 	// Pull each externalized subobject back into the host's package and null the
-	// soft refs. Used on External -> Embedded toggle. CompactShared's load-back path
+	// soft refs. Used on External -> Embedded toggle. CompactSharedSlot's load-back path
 	// also rehydrates shared collections lazily, but per-entry assets need explicit
 	// internalization here because they have no equivalent build-time fallback.
 	using namespace PCGExSharedCompact;
 
-	Internalize(*State.SharedMeshCollection, *State.ExternalSharedMeshCollection, State.Host);
-	Internalize(*State.SharedLevelCollection, *State.ExternalSharedLevelCollection, State.Host);
+	for (FPCGExExportCollectionSlot& Slot : *State.SharedSlots)
+	{
+		Internalize(Slot.Collection, Slot.External, State.Host);
+	}
 
 	for (FPCGExPCGDataAssetCollectionEntry* EntryPtr : State.Entries)
 	{
 		FPCGExPCGDataAssetCollectionEntry& Entry = *EntryPtr;
-		Internalize(Entry.EmbeddedActorCollection, Entry.ExternalActorCollection, State.Host);
+		for (FPCGExExportCollectionSlot& Slot : Entry.EmbeddedSlots)
+		{
+			Internalize(Slot.Collection, Slot.External, State.Host);
+		}
 		Internalize(Entry.ExportedDataAsset, Entry.ExternalExportedDataAsset, State.Host);
 		if (Entry.ExportedDataAsset)
 		{
@@ -1339,8 +1240,7 @@ void UPCGExPCGDataAssetCollection::InternalizeSubobjectsFor(FPCGExPCGDataAssetMa
 
 void UPCGExPCGDataAssetCollection::CollectExternalPackagesFor(
 	const UPCGExAssetCollection* Host,
-	const UPCGExMeshCollection* InSharedMesh,
-	const UPCGExLevelCollection* InSharedLevel,
+	const TArray<FPCGExExportCollectionSlot>& InSharedSlots,
 	const TArray<const FPCGExPCGDataAssetCollectionEntry*>& InEntries,
 	TSet<UPackage*>& OutPackages)
 {
@@ -1362,11 +1262,16 @@ void UPCGExPCGDataAssetCollection::CollectExternalPackagesFor(
 		}
 	};
 
-	AddPackageFor(InSharedMesh);
-	AddPackageFor(InSharedLevel);
+	for (const FPCGExExportCollectionSlot& Slot : InSharedSlots)
+	{
+		AddPackageFor(Slot.Collection);
+	}
 	for (const FPCGExPCGDataAssetCollectionEntry* Entry : InEntries)
 	{
-		AddPackageFor(Entry->EmbeddedActorCollection);
+		for (const FPCGExExportCollectionSlot& Slot : Entry->EmbeddedSlots)
+		{
+			AddPackageFor(Slot.Collection);
+		}
 		AddPackageFor(Entry->ExportedDataAsset);
 	}
 #endif
@@ -1384,7 +1289,7 @@ void UPCGExPCGDataAssetCollection::SaveExternalPackagesFor(FPCGExPCGDataAssetMac
 	ConstEntries.Append(State.Entries);
 
 	TSet<UPackage*> Packages;
-	CollectExternalPackagesFor(State.Host, *State.SharedMeshCollection, *State.SharedLevelCollection, ConstEntries, Packages);
+	CollectExternalPackagesFor(State.Host, *State.SharedSlots, ConstEntries, Packages);
 
 	for (UPackage* Pkg : Packages)
 	{
@@ -1399,13 +1304,12 @@ void UPCGExPCGDataAssetCollection::SaveExternalPackagesFor(FPCGExPCGDataAssetMac
 
 void UPCGExPCGDataAssetCollection::RebuildSharedCollectionsFor(FPCGExPCGDataAssetMachinery& State)
 {
-	CompactSharedMeshFor(State);
-	CompactSharedLevelFor(State);
+	CompactSharedFor(State);
 
-	// Externalize Shared* + per-entry actor collections BEFORE the CollectionMap is baked
+	// Externalize shared + per-entry slot collections BEFORE the CollectionMap is baked
 	// so the soft paths recorded in the map already point at their external packages.
 	// Externalize* cores short-circuit internally when external mode isn't active.
-	ExternalizeSharedAndActorCollectionsFor(State);
+	ExternalizeSlotCollectionsFor(State);
 
 	RebuildCollectionMapsFor(State);
 
@@ -1435,25 +1339,26 @@ void UPCGExPCGDataAssetCollection::RebuildSharedCollections()
 	}
 }
 
-void UPCGExPCGDataAssetCollection::ScrubSharedRefsForSave(TObjectPtr<UPCGExMeshCollection>& MeshSlot, TObjectPtr<UPCGExLevelCollection>& LevelSlot, FPCGExPCGDataSharedScrubKeep& OutKeep)
+void UPCGExPCGDataAssetCollection::ScrubSharedRefsForSave(TArray<FPCGExExportCollectionSlot>& Slots, FPCGExPCGDataSharedScrubKeep& OutKeep)
 {
-	OutKeep.MeshSlot = &MeshSlot;
-	OutKeep.LevelSlot = &LevelSlot;
-	OutKeep.KeptMesh = MeshSlot;
-	OutKeep.KeptLevel = LevelSlot;
-	MeshSlot = nullptr;
-	LevelSlot = nullptr;
+	OutKeep.Slots = &Slots;
+	OutKeep.Kept.SetNum(Slots.Num());
+	for (int32 i = 0; i < Slots.Num(); i++)
+	{
+		OutKeep.Kept[i] = Slots[i].Collection;
+		Slots[i].Collection = nullptr;
+	}
 }
 
 void UPCGExPCGDataAssetCollection::RestoreSharedRefsAfterSave(FPCGExPCGDataSharedScrubKeep& Keep)
 {
-	if (Keep.MeshSlot)
+	if (Keep.Slots)
 	{
-		*Keep.MeshSlot = Keep.KeptMesh;
-	}
-	if (Keep.LevelSlot)
-	{
-		*Keep.LevelSlot = Keep.KeptLevel;
+		const int32 N = FMath::Min(Keep.Slots->Num(), Keep.Kept.Num());
+		for (int32 i = 0; i < N; i++)
+		{
+			(*Keep.Slots)[i].Collection = Keep.Kept[i];
+		}
 	}
 	Keep = FPCGExPCGDataSharedScrubKeep();
 }
@@ -1463,15 +1368,21 @@ void UPCGExPCGDataAssetCollection::ScrubEntryRefsForSave(const TArray<FPCGExPCGD
 	OutKeep.Reset();
 	OutKeep.Entries.Reserve(InEntries.Num());
 	OutKeep.Data.Reserve(InEntries.Num());
-	OutKeep.Actors.Reserve(InEntries.Num());
+	OutKeep.Embedded.Reserve(InEntries.Num());
 
 	for (FPCGExPCGDataAssetCollectionEntry* Entry : InEntries)
 	{
 		OutKeep.Entries.Add(Entry);
 		OutKeep.Data.Add(Entry->ExportedDataAsset);
-		OutKeep.Actors.Add(Entry->EmbeddedActorCollection);
 		Entry->ExportedDataAsset = nullptr;
-		Entry->EmbeddedActorCollection = nullptr;
+
+		TArray<TObjectPtr<UPCGExAssetCollection>>& Kept = OutKeep.Embedded.AddDefaulted_GetRef();
+		Kept.SetNum(Entry->EmbeddedSlots.Num());
+		for (int32 i = 0; i < Entry->EmbeddedSlots.Num(); i++)
+		{
+			Kept[i] = Entry->EmbeddedSlots[i].Collection;
+			Entry->EmbeddedSlots[i].Collection = nullptr;
+		}
 	}
 }
 
@@ -1479,8 +1390,14 @@ void UPCGExPCGDataAssetCollection::RestoreEntryRefsAfterSave(FPCGExPCGDataEntryS
 {
 	for (int32 i = 0; i < Keep.Entries.Num(); i++)
 	{
-		Keep.Entries[i]->ExportedDataAsset = Keep.Data[i];
-		Keep.Entries[i]->EmbeddedActorCollection = Keep.Actors[i];
+		FPCGExPCGDataAssetCollectionEntry* Entry = Keep.Entries[i];
+		Entry->ExportedDataAsset = Keep.Data[i];
+		const TArray<TObjectPtr<UPCGExAssetCollection>>& Kept = Keep.Embedded[i];
+		const int32 N = FMath::Min(Kept.Num(), Entry->EmbeddedSlots.Num());
+		for (int32 s = 0; s < N; s++)
+		{
+			Entry->EmbeddedSlots[s].Collection = Kept[s];
+		}
 	}
 	Keep.Reset();
 }
@@ -1625,49 +1542,40 @@ void UPCGExPCGDataAssetCollection::EDITOR_AddBrowserSelectionInternal(const TArr
 }
 
 void UPCGExPCGDataAssetCollection::AppendCookDependencyAssetPathsFor(
-	const UPCGExMeshCollection* InSharedMesh,
-	const UPCGExLevelCollection* InSharedLevel,
-	const TSoftObjectPtr<UPCGExMeshCollection>& InExternalSharedMesh,
-	const TSoftObjectPtr<UPCGExLevelCollection>& InExternalSharedLevel,
+	const TArray<FPCGExExportCollectionSlot>& InSharedSlots,
 	const TArray<const FPCGExPCGDataAssetCollectionEntry*>& InEntries,
 	TSet<FSoftObjectPath>& OutPaths)
 {
-	// Embedded shared collections live in the host's package so the package itself is
-	// already in the cook -- but their *entries* hold soft refs to the actual meshes /
-	// levels which cook traversal won't reach on its own.
-	if (InSharedMesh)
+	// Embedded slot collections live in the host's package so the package itself is already in the
+	// cook -- but their *entries* hold soft refs to the actual meshes / levels / sketches which cook
+	// traversal won't reach on its own. Externalized ones sit in their own packages -- surface them so
+	// the ModifyCook scan force-cooks those packages too; once cooked, the registry scan re-enters them
+	// (they're UPCGExAssetCollection subclasses and implement the interface), so their leaf soft refs
+	// follow automatically.
+	auto AppendSlot = [&OutPaths](const FPCGExExportCollectionSlot& Slot)
 	{
-		InSharedMesh->GetAssetPaths(OutPaths, PCGExAssetCollection::ELoadingFlags::Recursive);
-	}
-	if (InSharedLevel)
+		if (Slot.Collection)
+		{
+			Slot.Collection->GetAssetPaths(OutPaths, PCGExAssetCollection::ELoadingFlags::Recursive);
+		}
+		if (!Slot.External.IsNull())
+		{
+			OutPaths.Add(Slot.External.ToSoftObjectPath());
+		}
+	};
+
+	for (const FPCGExExportCollectionSlot& Slot : InSharedSlots)
 	{
-		InSharedLevel->GetAssetPaths(OutPaths, PCGExAssetCollection::ELoadingFlags::Recursive);
+		AppendSlot(Slot);
 	}
 
-	// Externalized shared collections sit in their own packages -- surface them so the
-	// ModifyCook scan force-cooks those packages too. Once cooked, our registry scan
-	// re-enters them (they're UPCGExAssetCollection subclasses and implement the interface),
-	// so their leaf soft refs follow automatically.
-	if (!InExternalSharedMesh.IsNull())
-	{
-		OutPaths.Add(InExternalSharedMesh.ToSoftObjectPath());
-	}
-	if (!InExternalSharedLevel.IsNull())
-	{
-		OutPaths.Add(InExternalSharedLevel.ToSoftObjectPath());
-	}
-
-	// Per-entry actor collections (embedded + external). Hang off the entry as hard
-	// subobjects rather than entries[], so the base walk skips them.
+	// Per-entry slot collections hang off the entry as hard subobjects rather than entries[], so the
+	// base walk skips them.
 	for (const FPCGExPCGDataAssetCollectionEntry* Entry : InEntries)
 	{
-		if (Entry->EmbeddedActorCollection)
+		for (const FPCGExExportCollectionSlot& Slot : Entry->EmbeddedSlots)
 		{
-			Entry->EmbeddedActorCollection->GetAssetPaths(OutPaths, PCGExAssetCollection::ELoadingFlags::Recursive);
-		}
-		if (!Entry->ExternalActorCollection.IsNull())
-		{
-			OutPaths.Add(Entry->ExternalActorCollection.ToSoftObjectPath());
+			AppendSlot(Slot);
 		}
 	}
 }
@@ -1707,10 +1615,7 @@ FPCGExPCGDataAssetMachinery UPCGExPCGDataTypeState::MakeMachinery(UPCGExAssetCol
 		});
 	}
 
-	State.SharedMeshCollection = &SharedMeshCollection;
-	State.SharedLevelCollection = &SharedLevelCollection;
-	State.ExternalSharedMeshCollection = &ExternalSharedMeshCollection;
-	State.ExternalSharedLevelCollection = &ExternalSharedLevelCollection;
+	State.SharedSlots = &SharedSlots;
 
 	State.bExternalActive = IsExternalActive();
 	State.ExportFolderPath = ExportFolder.Path;
@@ -1784,7 +1689,7 @@ void UPCGExPCGDataTypeState::Serialize(FArchive& Ar)
 	if (IsExternalActive() && Ar.IsSaving() && !Ar.IsTransacting())
 	{
 		FPCGExPCGDataSharedScrubKeep SharedKeep;
-		UPCGExPCGDataAssetCollection::ScrubSharedRefsForSave(SharedMeshCollection, SharedLevelCollection, SharedKeep);
+		UPCGExPCGDataAssetCollection::ScrubSharedRefsForSave(SharedSlots, SharedKeep);
 
 		Super::Serialize(Ar);
 
@@ -1793,6 +1698,37 @@ void UPCGExPCGDataTypeState::Serialize(FArchive& Ar)
 	else
 	{
 		Super::Serialize(Ar);
+	}
+}
+
+void UPCGExPCGDataTypeState::PostLoad()
+{
+	Super::PostLoad();
+
+	AdoptLegacySlot(PCGExLevelExport::Slots::Meshes, SharedMeshCollection_DEPRECATED, ExternalSharedMeshCollection_DEPRECATED.ToSoftObjectPath());
+	SharedMeshCollection_DEPRECATED = nullptr;
+	ExternalSharedMeshCollection_DEPRECATED.Reset();
+
+	AdoptLegacySlot(PCGExLevelExport::Slots::Levels, SharedLevelCollection_DEPRECATED, ExternalSharedLevelCollection_DEPRECATED.ToSoftObjectPath());
+	SharedLevelCollection_DEPRECATED = nullptr;
+	ExternalSharedLevelCollection_DEPRECATED.Reset();
+}
+
+void UPCGExPCGDataTypeState::AdoptLegacySlot(const FName SlotId, UPCGExAssetCollection* Collection, const FSoftObjectPath& External)
+{
+	if (!Collection && External.IsNull())
+	{
+		return;
+	}
+
+	FPCGExExportCollectionSlot& Slot = PCGExExportSlots::FindOrAdd(SharedSlots, SlotId);
+	if (!Slot.Collection && Collection)
+	{
+		Slot.Collection = Collection;
+	}
+	if (Slot.External.IsNull() && !External.IsNull())
+	{
+		Slot.External = TSoftObjectPtr<UPCGExAssetCollection>(External);
 	}
 }
 
@@ -1840,10 +1776,7 @@ void UPCGExPCGDataTypeState::AppendCookDependencyAssetPaths(const UPCGExAssetCol
 		});
 	}
 
-	UPCGExPCGDataAssetCollection::AppendCookDependencyAssetPathsFor(
-		SharedMeshCollection, SharedLevelCollection,
-		ExternalSharedMeshCollection, ExternalSharedLevelCollection,
-		EntryPtrs, OutPaths);
+	UPCGExPCGDataAssetCollection::AppendCookDependencyAssetPathsFor(SharedSlots, EntryPtrs, OutPaths);
 }
 
 void UPCGExPCGDataTypeState::EDITOR_AppendExternalPackages(const UPCGExAssetCollection* Host, TSet<UPackage*>& OutPackages) const
@@ -1862,8 +1795,7 @@ void UPCGExPCGDataTypeState::EDITOR_AppendExternalPackages(const UPCGExAssetColl
 		});
 	}
 
-	UPCGExPCGDataAssetCollection::CollectExternalPackagesFor(
-		Host, SharedMeshCollection, SharedLevelCollection, EntryPtrs, OutPackages);
+	UPCGExPCGDataAssetCollection::CollectExternalPackagesFor(Host, SharedSlots, EntryPtrs, OutPackages);
 }
 
 void UPCGExPCGDataTypeState::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
@@ -1946,13 +1878,20 @@ void UPCGExPCGDataTypeState::OnRemovedFromHost(UPCGExAssetCollection* Host)
 	// Teardown surface: external packages this machinery produced stay on disk (deleting
 	// user-visible assets here would be data loss) -- but with the state gone nothing
 	// references them anymore. Say so instead of orphaning silently.
-	if (!ExternalSharedMeshCollection.IsNull() || !ExternalSharedLevelCollection.IsNull())
+	TArray<FString> Externals;
+	for (const FPCGExExportCollectionSlot& Slot : SharedSlots)
+	{
+		if (!Slot.External.IsNull())
+		{
+			Externals.Add(Slot.External.ToSoftObjectPath().ToString());
+		}
+	}
+	if (!Externals.IsEmpty())
 	{
 		UE_LOG(LogPCGEx, Warning,
-		       TEXT("'%s': the removed PCG Data Asset machinery state still pointed at externalized packages ('%s', '%s'). They remain on disk, now orphaned -- delete them manually, or undo, re-add PCGData entries and disable external storage first to internalize them."),
+		       TEXT("'%s': the removed PCG Data Asset machinery state still pointed at externalized packages (%s). They remain on disk, now orphaned -- delete them manually, or undo, re-add PCGData entries and disable external storage first to internalize them."),
 		       Host ? *Host->GetName() : TEXT("<null>"),
-		       *ExternalSharedMeshCollection.ToSoftObjectPath().ToString(),
-		       *ExternalSharedLevelCollection.ToSoftObjectPath().ToString());
+		       *FString::Join(Externals, TEXT(", ")));
 	}
 }
 

--- a/Source/PCGExCollections/Private/Core/PCGExCollectionHelpers.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExCollectionHelpers.cpp
@@ -7,6 +7,7 @@
 #include "Core/PCGExAssetCollection.h"
 #include "Data/PCGExAttributeBroadcaster.h"
 #include "Details/PCGExStagingDetails.h"
+#include "UObject/Package.h"
 #include "UObject/UnrealType.h"
 
 namespace PCGExCollectionHelpers
@@ -400,6 +401,52 @@ namespace PCGExCollectionHelpers
 			if (Current && Current->GetOuter() != NewOuter)
 			{
 				ObjProp->SetObjectPropertyValue_InContainer(StructMemory, DuplicateObject(Current, NewOuter));
+			}
+		}
+	}
+
+	void RetireInstancedSubobjects(const UScriptStruct* Struct, void* StructMemory)
+	{
+		if (!Struct || !StructMemory)
+		{
+			return;
+		}
+
+		for (TFieldIterator<FObjectPropertyBase> It(Struct); It; ++It)
+		{
+			const FObjectPropertyBase* ObjProp = *It;
+			if (!ObjProp->HasAnyPropertyFlags(CPF_InstancedReference))
+			{
+				continue;
+			}
+
+			if (UObject* Current = ObjProp->GetObjectPropertyValue_InContainer(StructMemory))
+			{
+				Current->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors | REN_NonTransactional);
+				ObjProp->SetObjectPropertyValue_InContainer(StructMemory, nullptr);
+			}
+		}
+	}
+
+	void ReparentInstancedSubobjects(const UScriptStruct* Struct, void* StructMemory, UObject* NewOuter)
+	{
+		if (!Struct || !StructMemory || !NewOuter)
+		{
+			return;
+		}
+
+		for (TFieldIterator<FObjectPropertyBase> It(Struct); It; ++It)
+		{
+			const FObjectPropertyBase* ObjProp = *It;
+			if (!ObjProp->HasAnyPropertyFlags(CPF_InstancedReference))
+			{
+				continue;
+			}
+
+			UObject* Current = ObjProp->GetObjectPropertyValue_InContainer(StructMemory);
+			if (Current && Current->GetOuter() != NewOuter)
+			{
+				Current->Rename(nullptr, NewOuter, REN_DontCreateRedirectors | REN_NonTransactional);
 			}
 		}
 	}

--- a/Source/PCGExCollections/Private/Helpers/PCGExDefaultLevelDataExporter.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExDefaultLevelDataExporter.cpp
@@ -4,43 +4,27 @@
 #include "Helpers/PCGExDefaultLevelDataExporter.h"
 
 #include "PCGDataAsset.h"
-#include "PCGParamData.h"
-#include "Data/PCGPointArrayData.h"
-#include "Helpers/PCGExCollectionsHelpers.h"
-#include "Helpers/PCGExPointArrayDataHelpers.h"
-
-#include "Collections/PCGExActorCollection.h"
-#include "Collections/PCGExLevelCollection.h"
-#include "Collections/PCGExMeshCollection.h"
-#include "Collections/PCGExPCGDataAssetCollection.h"
-
-#include "Helpers/PCGExActorMeshClassificator.h"
-
-#include "UObject/Package.h"
-
-#include "Engine/Level.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
-
-#include "Components/InstancedStaticMeshComponent.h"
-#include "Components/StaticMeshComponent.h"
-#include "Materials/MaterialInterface.h"
-
+#include "Helpers/PCGExActorMeshClassificator.h"
 #include "LevelInstance/LevelInstanceActor.h"
-
-#include "PCGExLog.h"
-#include "PCGExPropertyCollectionComponent.h"
-#include "PCGExSchemaMerging.h"
-#include "Data/PCGExDataValue.h"
-#include "Data/Descriptors/PCGExComponentDescriptors.h"
-#include "Helpers/PCGExActorPropertyDelta.h"
-#include "Helpers/PCGExMetaHelpersMacros.h"
-
-#include "ISMPartition/ISMComponentDescriptor.h"
-#include "Serialization/ArchiveCrc32.h"
-
 #include "PCGExCollectionsSettingsCache.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectHash.h"
+
+#if WITH_EDITOR
+#include "Core/PCGExAssetCollection.h"
+#include "Core/PCGExCollectionHelpers.h"
+#include "Core/PCGExExportSlots.h"
+#include "Helpers/PCGExCollectionsHelpers.h"
+#include "Helpers/PCGExLevelExportBuiltinHandlers.h"
+#include "Helpers/PCGExLevelExportHandler.h"
+#include "Helpers/PCGExLevelExportShared.h"
+#include "Metadata/PCGMetadata.h"
+#endif
 
 UPCGExDefaultLevelDataExporter::UPCGExDefaultLevelDataExporter(const FObjectInitializer& ObjectInitializer)
 {
@@ -118,591 +102,29 @@ void UPCGExDefaultLevelDataExporter::OnExportComplete(UPCGDataAsset* OutAsset)
 	// Default: no-op. Override for custom post-export logic.
 }
 
-namespace PCGExDefaultLevelDataExporterInternal
-{
-	struct FClassifiedActor
-	{
-		AActor* Actor = nullptr;
-		EPCGExActorExportType Type = EPCGExActorExportType::Skip;
-		uint32 DeltaHash = 0;
-	};
-
-	/** Helper to allocate point data with transforms+bounds, init metadata, and return ranges */
-	static UPCGBasePointData* CreatePointData(
-		UObject* Outer, int32 NumPoints,
-		TPCGValueRange<FTransform>& OutTransforms,
-		TPCGValueRange<FVector>& OutBoundsMin,
-		TPCGValueRange<FVector>& OutBoundsMax)
-	{
-		UPCGBasePointData* PointData = NewObject<UPCGPointArrayData>(Outer);
-		PCGExPointArrayDataHelpers::SetNumPointsAllocated(
-			PointData, NumPoints,
-			EPCGPointNativeProperties::Transform | EPCGPointNativeProperties::BoundsMin | EPCGPointNativeProperties::BoundsMax);
-
-		OutTransforms = PointData->GetTransformValueRange();
-		OutBoundsMin = PointData->GetBoundsMinValueRange();
-		OutBoundsMax = PointData->GetBoundsMaxValueRange();
-
-		return PointData;
-	}
-
-	static void InitMetadata(UPCGBasePointData* PointData, int32 NumPoints)
-	{
-		UPCGMetadata* Meta = PointData->MutableMetadata();
-		TPCGValueRange<int64> MetaEntries = PointData->GetMetadataEntryValueRange();
-
-		TArray<TTuple<int64, int64>> DelayedEntries;
-		DelayedEntries.SetNum(NumPoints);
-
-		for (int32 i = 0; i < NumPoints; i++)
-		{
-			MetaEntries[i] = Meta->AddEntryPlaceholder();
-			DelayedEntries[i] = MakeTuple(MetaEntries[i], static_cast<int64>(-1));
-		}
-
-		Meta->AddDelayedEntries(DelayedEntries);
-	}
-
-	static void WorldBoundsToLocal(const FBox& WorldBounds, const FTransform& ActorTransform, FVector& OutBoundsMin, FVector& OutBoundsMax)
-	{
-		if (WorldBounds.IsValid)
-		{
-			const FTransform InvTransform = ActorTransform.Inverse();
-			const FVector LocalMin = InvTransform.TransformPosition(WorldBounds.Min);
-			const FVector LocalMax = InvTransform.TransformPosition(WorldBounds.Max);
-
-			// Re-min/max after transform (rotation can swap axes)
-			OutBoundsMin = LocalMin.ComponentMin(LocalMax);
-			OutBoundsMax = LocalMin.ComponentMax(LocalMax);
-		}
-		else
-		{
-			OutBoundsMin = FVector::ZeroVector;
-			OutBoundsMax = FVector::ZeroVector;
-		}
-	}
-
-	// Bounds stay relative to the actor's own transform (frame-invariant); only the written
-	// transform moves into the source frame.
-	static void WriteActorTransformAndBounds(
-		AActor* Actor, int32 Index,
-		const FPCGExLevelExportSource& Source,
-		const UPCGExBoundsEvaluator* Evaluator,
-		TPCGValueRange<FTransform>& Transforms,
-		TPCGValueRange<FVector>& BoundsMin,
-		TPCGValueRange<FVector>& BoundsMax)
-	{
-		const FTransform ActorTransform = Actor->GetActorTransform();
-		Transforms[Index] = Source.ToFrame(ActorTransform);
-
-		const FBox WorldBounds = Evaluator ? Evaluator->EvaluateActorBounds(Actor, nullptr, -1) : FBox(ForceInit);
-		WorldBoundsToLocal(WorldBounds, ActorTransform, BoundsMin[Index], BoundsMax[Index]);
-	}
-
-	// Components share an entry only when they agree on mesh, source kind, AND the
-	// descriptor fingerprint (every UPROPERTY except OverrideMaterials -- those become
-	// per-entry variants instead). Different mobility / collision / body instance /
-	// light map / etc. → distinct entry, descriptor preserved on each.
-	//
-	// PropertyComponentHash is folded in so two mesh actors that share mesh+descriptor but
-	// author distinct UPCGExPropertyCollectionComponent values land in distinct entries --
-	// otherwise their per-instance property data would silently collapse into one bucket.
-	struct FMeshEntryKey
-	{
-		FSoftObjectPath MeshPath;
-		uint32 DescriptorFingerprint = 0;
-		bool bIsISMSource = false;
-		uint32 PropertyComponentHash = 0;
-
-		bool operator==(const FMeshEntryKey& Other) const
-		{
-			return MeshPath == Other.MeshPath
-				&& DescriptorFingerprint == Other.DescriptorFingerprint
-				&& bIsISMSource == Other.bIsISMSource
-				&& PropertyComponentHash == Other.PropertyComponentHash;
-		}
-
-		friend uint32 GetTypeHash(const FMeshEntryKey& Key)
-		{
-			return HashCombine(
-				HashCombine(
-					HashCombine(GetTypeHash(Key.MeshPath), Key.DescriptorFingerprint),
-					Key.bIsISMSource ? 1u : 0u),
-				Key.PropertyComponentHash);
-		}
-	};
-
-	struct FMeshPoint
-	{
-		FTransform Transform;
-		FVector BoundsMin = FVector::ZeroVector;
-		FVector BoundsMax = FVector::ZeroVector;
-		FMeshEntryKey EntryKey;
-		const UStaticMeshComponent* SourceComponent = nullptr;
-		AActor* SourceActor = nullptr;
-		int32 MaterialVariantIndex = -1;
-	};
-
-	struct FMeshInfo
-	{
-		int32 EntryIndex = -1;
-		int32 TotalCount = 0;
-		// Authoritative for the entry; the kind matching the source key is populated,
-		// the other stays at engine defaults. Subsequent contributors share the
-		// fingerprint by construction, so first-write-wins is a tautology, not a guess.
-		FSoftISMComponentDescriptor ISMDescriptor;
-		FPCGExStaticMeshComponentDescriptor SMDescriptor;
-		TArray<TArray<FSoftObjectPath>> UniqueVariantMaterials;
-		TMap<uint32, int32> VariantHashToIndex;
-
-		// Source actor we treat as the representative donor for property-component scanning.
-		// Captured on first contribution; all subsequent contributors share the same property
-		// hash by construction (it's part of the key), so any one of them is a valid donor.
-		TWeakObjectPtr<AActor> RepresentativeActor;
-	};
-
-	struct FActorClassInfo
-	{
-		int32 EntryIndex = -1;
-		TSet<FName> IntersectedTags;
-		bool bFirstActor = true;
-		int32 Count = 0;
-		TArray<uint8> SerializedDelta;
-		TArray<FSoftObjectPath> CollateralPaths;
-
-		// Live actor we treat as the representative for this (class, delta) bucket. Captured
-		// when the first actor of the bucket is seen; carried through so the post-build property-
-		// component scan can pull authored values directly from a real instance instead of
-		// re-resolving the delta. All actors in the bucket share an identical delta hash, so
-		// any one of them is a valid donor; "first wins" matches the SerializedDelta capture.
-		TWeakObjectPtr<AActor> RepresentativeActor;
-	};
-
-	struct FActorInstanceKey
-	{
-		FSoftClassPath ClassPath;
-		uint32 DeltaHash = 0;
-
-		bool operator==(const FActorInstanceKey& Other) const
-		{
-			return ClassPath == Other.ClassPath && DeltaHash == Other.DeltaHash;
-		}
-
-		friend uint32 GetTypeHash(const FActorInstanceKey& Key)
-		{
-			return HashCombine(GetTypeHash(Key.ClassPath), Key.DeltaHash);
-		}
-	};
-
-	struct FLevelInfo
-	{
-		int32 EntryIndex = -1;
-		int32 Count = 0;
-	};
-
-	static uint32 HashMaterials(const UStaticMeshComponent* Comp)
-	{
-		uint32 H = 0;
-		for (int32 i = 0; i < Comp->GetNumOverrideMaterials(); i++)
-		{
-			if (UMaterialInterface* M = Comp->GetMaterial(i))
-			{
-				H = HashCombine(H, GetTypeHash(FSoftObjectPath(M)));
-			}
-		}
-		return H;
-	}
-
-	// Per-export-pass cache of (Resolved schema, Hash) keyed by source actor. ExtractSchemaFromActor
-	// is the expensive step (BP PreparePropertyValues thunk + class-chain walk + per-entry struct
-	// copy) and we need its result twice per actor: once to bucket by PropertyComponentHash, once
-	// to seed PropertyOverrides on the bucket representative. Compute once, read twice.
-	struct FActorPropertySchemaCache
-	{
-		TArray<FInstancedStruct> Resolved;
-		uint32 Hash = 0;
-	};
-
-	// Resolve + hash an actor's property-component schema, memoized by AActor*. Empty/no-component
-	// actors land in the cache with Hash=0 and Resolved empty so subsequent lookups are O(1). The
-	// hash is over the *effective* extracted schema (matching ExtractSchemaFromActor semantics:
-	// BP class chain + PreparePropertyValues), not raw component state -- a raw-state hash would
-	// collapse actors that resolve to different values via the chain into the same bucket.
-	static const FActorPropertySchemaCache& GetOrComputeActorPropertySchema(
-		AActor* Actor,
-		TMap<AActor*, FActorPropertySchemaCache>& Cache)
-	{
-		if (const FActorPropertySchemaCache* Found = Cache.Find(Actor))
-		{
-			return *Found;
-		}
-		FActorPropertySchemaCache& Entry = Cache.Add(Actor);
-
-		if (!Actor || !UPCGExPropertyCollectionComponent::FindOnActor(Actor))
-		{
-			return Entry;
-		}
-
-		Entry.Resolved = UPCGExPropertyCollectionComponent::ExtractSchemaFromActor(Actor);
-		if (Entry.Resolved.IsEmpty())
-		{
-			return Entry;
-		}
-
-		FArchiveCrc32 Crc;
-		for (const FInstancedStruct& Prop : Entry.Resolved)
-		{
-			const UScriptStruct* ScriptStruct = Prop.GetScriptStruct();
-			if (!ScriptStruct)
-			{
-				continue;
-			}
-
-			// Type path prefix so two values of different types but matching byte layout don't alias.
-			FString TypeName = ScriptStruct->GetPathName();
-			Crc << TypeName;
-
-			const_cast<UScriptStruct*>(ScriptStruct)->SerializeItem(
-				FStructuredArchiveFromArchive(Crc).GetSlot(),
-				const_cast<uint8*>(Prop.GetMemory()), nullptr);
-		}
-		Entry.Hash = Crc.GetCrc();
-		return Entry;
-	}
-
-	static int32 TrackMaterialVariant(const UStaticMeshComponent* Comp, FMeshInfo& Info)
-	{
-		if (!Comp)
-		{
-			return -1;
-		}
-
-		const uint32 MatHash = HashMaterials(Comp);
-		if (MatHash == 0)
-		{
-			return -1;
-		}
-
-		if (const int32* Existing = Info.VariantHashToIndex.Find(MatHash))
-		{
-			return *Existing;
-		}
-
-		const int32 VariantIdx = Info.UniqueVariantMaterials.Num();
-		Info.VariantHashToIndex.Add(MatHash, VariantIdx);
-
-		TArray<FSoftObjectPath>& Mats = Info.UniqueVariantMaterials.AddDefaulted_GetRef();
-		for (int32 i = 0; i < Comp->GetNumOverrideMaterials(); i++)
-		{
-			if (UMaterialInterface* M = Comp->GetMaterial(i))
-			{
-				Mats.Add(FSoftObjectPath(M));
-			}
-			else
-			{
-				Mats.Add(FSoftObjectPath());
-			}
-		}
-
-		return VariantIdx;
-	}
-
-	// Non-const ref because FSoftISMComponentDescriptor's copy ctor is `explicit`,
-	// blocking a local-copy form. Save-restore on the original lets us strip
-	// OverrideMaterials transiently without mutating observable state -- those go on
-	// the entry as variants, so they shouldn't influence descriptor identity.
-	template <typename TDescriptor>
-	static uint32 FingerprintDescriptor(TDescriptor& Descriptor)
-	{
-		decltype(Descriptor.OverrideMaterials) SavedMaterials = MoveTemp(Descriptor.OverrideMaterials);
-		Descriptor.OverrideMaterials.Reset();
-
-		FArchiveCrc32 CrcArchive;
-		TDescriptor::StaticStruct()->SerializeBin(CrcArchive, &Descriptor);
-		const uint32 Crc = CrcArchive.GetCrc();
-
-		Descriptor.OverrideMaterials = MoveTemp(SavedMaterials);
-		return Crc;
-	}
-
-	// Unified mesh-point extraction for a single Mesh-classified actor. Mesh and
-	// Actor classifications are mutually exclusive -- Actor-classified actors with
-	// ISMCs are intentionally NOT harvested here. Bounds are the mesh's intrinsic
-	// local AABB; BoundsEvaluator is not consulted because component variation
-	// belongs on per-entry descriptor data, not a coarse per-actor world AABB.
-	static void ExtractMeshPointsFromActor(
-		AActor* Actor,
-		const FPCGExLevelExportSource& Source,
-		bool bCaptureMaterialOverrides,
-		TArray<FMeshPoint>& OutPoints,
-		TMap<FMeshEntryKey, FMeshInfo>& InOutMeshInfoMap,
-		TMap<AActor*, FActorPropertySchemaCache>& PropertySchemaCache)
-	{
-		// Property-component identity is computed once per actor and folded into every mesh
-		// entry this actor contributes to. Actors that author distinct property values land
-		// in distinct mesh buckets so their per-instance PropertyOverrides survive merging.
-		const uint32 PropertyComponentHash = GetOrComputeActorPropertySchema(Actor, PropertySchemaCache).Hash;
-
-		TInlineComponentArray<UStaticMeshComponent*> SMCs;
-		Actor->GetComponents<UStaticMeshComponent>(SMCs);
-
-		for (UStaticMeshComponent* SMC : SMCs)
-		{
-			if (!SMC)
-			{
-				continue;
-			}
-
-			UStaticMesh* Mesh = SMC->GetStaticMesh();
-			if (!Mesh)
-			{
-				continue;
-			}
-
-			UInstancedStaticMeshComponent* ISMC = Cast<UInstancedStaticMeshComponent>(SMC);
-			const bool bIsISM = ISMC != nullptr;
-
-			FMeshEntryKey Key;
-			Key.MeshPath = FSoftObjectPath(Mesh);
-			Key.bIsISMSource = bIsISM;
-			Key.PropertyComponentHash = PropertyComponentHash;
-
-			FSoftISMComponentDescriptor TentativeISM;
-			FPCGExStaticMeshComponentDescriptor TentativeSM;
-
-			if (bIsISM)
-			{
-				TentativeISM.InitFrom(SMC, /*bInitBodyInstance=*/false);
-				Key.DescriptorFingerprint = FingerprintDescriptor(TentativeISM);
-			}
-			else
-			{
-				TentativeSM.InitFrom(SMC, /*bInitBodyInstance=*/false);
-				Key.DescriptorFingerprint = FingerprintDescriptor(TentativeSM);
-			}
-
-			// When capturing, variants are the sole material carrier: sec=-1 must mean mesh
-			// defaults, so the stored descriptor must not bake one contributor's overrides.
-			if (bCaptureMaterialOverrides)
-			{
-				TentativeISM.OverrideMaterials.Reset();
-				TentativeSM.OverrideMaterials.Reset();
-			}
-
-			FMeshInfo& Info = InOutMeshInfoMap.FindOrAdd(Key);
-
-			// First contribution stores the descriptor; subsequent contributors are
-			// equivalent by fingerprint so the stored value is canonical.
-			if (Info.TotalCount == 0)
-			{
-				if (bIsISM)
-				{
-					Info.ISMDescriptor = MoveTemp(TentativeISM);
-				}
-				else
-				{
-					Info.SMDescriptor = MoveTemp(TentativeSM);
-				}
-				// All contributors to this bucket share PropertyComponentHash by construction,
-				// so the first actor's property data is canonical for the bucket.
-				Info.RepresentativeActor = Actor;
-			}
-
-			const int32 VariantIdx = bCaptureMaterialOverrides
-				? TrackMaterialVariant(SMC, Info)
-				: -1;
-
-			const FBox MeshBounds = Mesh->GetBoundingBox();
-
-			if (bIsISM)
-			{
-				const int32 InstanceCount = ISMC->GetInstanceCount();
-				if (InstanceCount == 0)
-				{
-					continue;
-				}
-
-				Info.TotalCount += InstanceCount;
-				OutPoints.Reserve(OutPoints.Num() + InstanceCount);
-
-				for (int32 Idx = 0; Idx < InstanceCount; Idx++)
-				{
-					FMeshPoint& Point = OutPoints.AddDefaulted_GetRef();
-					Point.EntryKey = Key;
-					Point.SourceComponent = ISMC;
-					Point.SourceActor = Actor;
-					Point.MaterialVariantIndex = VariantIdx;
-					Point.BoundsMin = MeshBounds.Min;
-					Point.BoundsMax = MeshBounds.Max;
-					FTransform InstanceWorld;
-					ISMC->GetInstanceTransform(Idx, InstanceWorld, /*bWorldSpace=*/true);
-					Point.Transform = Source.ToFrame(InstanceWorld);
-				}
-			}
-			else
-			{
-				Info.TotalCount++;
-
-				FMeshPoint& Point = OutPoints.AddDefaulted_GetRef();
-				Point.EntryKey = Key;
-				Point.SourceComponent = SMC;
-				Point.SourceActor = Actor;
-				Point.MaterialVariantIndex = VariantIdx;
-				Point.Transform = Source.ToFrame(SMC->GetComponentTransform());
-				Point.BoundsMin = MeshBounds.Min;
-				Point.BoundsMax = MeshBounds.Max;
-			}
-		}
-	}
-
-	// Registry that tracks which attribute name maps to which PCG metadata type.
-	// First registration wins; subsequent conflicts are warned and discarded.
-	struct FValueTagRegistry
-	{
-		TMap<FName, EPCGMetadataTypes> TypeMap;
-
-		bool Register(const FName& Name, EPCGMetadataTypes NewType, const FString& SourceActorName)
-		{
-			if (const EPCGMetadataTypes* Existing = TypeMap.Find(Name))
-			{
-				if (*Existing != NewType)
-				{
-					UE_LOG(LogPCGEx, Warning,
-					       TEXT("Value tag type conflict: '%s' on actor '%s'. Attribute was already registered with a different type; this actor's value will be discarded."),
-					       *Name.ToString(), *SourceActorName);
-					return false;
-				}
-				return true;
-			}
-			TypeMap.Add(Name, NewType);
-			return true;
-		}
-	};
-
-	// Per-actor parsed tag result.
-	// PlainTags: tags with no colon (or unrecognized format) → become bool=true attributes.
-	// ValueTags: Name:Value tags → become typed attributes.
-	// Under ParseAndKeep, the name-part of each ValueTag is also written to the instance tag string
-	// (handled at the call site by iterating both arrays).
-	struct FParsedActorTags
-	{
-		TArray<FName> PlainTags;
-		TArray<TPair<FName, TSharedPtr<PCGExData::IDataValue>>> ValueTags;
-	};
-
-	static FParsedActorTags ParseActorTags(const AActor* Actor, FValueTagRegistry& Registry)
-	{
-		FParsedActorTags Result;
-		const FString ActorName = Actor->GetActorNameOrLabel();
-
-		for (const FName& Tag : Actor->Tags)
-		{
-			FString Key;
-			const TSharedPtr<PCGExData::IDataValue> DataValue = PCGExData::TryGetValueFromTag(Tag.ToString(), Key);
-
-			if (DataValue.IsValid())
-			{
-				const FName AttrName(Key);
-				if (Registry.Register(AttrName, DataValue->GetTypeId(), ActorName))
-				{
-					Result.ValueTags.Add(TPair<FName, TSharedPtr<PCGExData::IDataValue>>(AttrName, DataValue));
-				}
-				// Note: name-parts of value tags are intentionally NOT added to PlainTags.
-				// They appear in the instance tag string only via the ValueTags array (ParseAndKeep).
-			}
-			else
-			{
-				// Plain tag → will become a bool=true attribute
-				if (Registry.Register(Tag, EPCGMetadataTypes::Boolean, ActorName))
-				{
-					Result.PlainTags.Add(Tag);
-				}
-			}
-		}
-		return Result;
-	}
-
-	// Creates one typed PCG metadata attribute per registry entry; returns a map of base ptrs for fast per-point writes.
-	static TMap<FName, FPCGMetadataAttributeBase*> CreateValueTagAttributes(UPCGMetadata* Meta, const FValueTagRegistry& Registry)
-	{
-		TMap<FName, FPCGMetadataAttributeBase*> AttrMap;
-		AttrMap.Reserve(Registry.TypeMap.Num());
-
-		for (const TPair<FName, EPCGMetadataTypes>& Elem : Registry.TypeMap)
-		{
-			const FName& Name = Elem.Key;
-			FPCGMetadataAttributeBase* Attr = nullptr;
-#define PCGEX_CREATE_VALUE_TAG_ATTR(_TYPE, _NAME) Attr = Meta->CreateAttribute<_TYPE>(Name, _TYPE{}, false, true);
-			PCGEX_EXECUTEWITHRIGHTTYPE(Elem.Value, PCGEX_CREATE_VALUE_TAG_ATTR)
-#undef PCGEX_CREATE_VALUE_TAG_ATTR
-			if (Attr)
-			{
-				AttrMap.Add(Name, Attr);
-			}
-		}
-		return AttrMap;
-	}
-
-	// Writes value-tag attributes for a single point.
-	// PlainTags → bool=true; ValueTags → typed value via base-ptr cast.
-	static void SetValueTagAttributes(
-		const TMap<FName, FPCGMetadataAttributeBase*>& AttrMap,
-		int64 Entry,
-		const FParsedActorTags& Parsed)
-	{
-		for (const FName& Tag : Parsed.PlainTags)
-		{
-			if (FPCGMetadataAttributeBase* const* BasePtr = AttrMap.Find(Tag))
-			{
-				static_cast<FPCGMetadataAttribute<bool>*>(*BasePtr)->SetValue(Entry, true);
-			}
-		}
-
-		for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
-		{
-			FPCGMetadataAttributeBase* const* BasePtr = AttrMap.Find(VT.Key);
-			if (!BasePtr)
-			{
-				continue;
-			}
-
-			FPCGMetadataAttributeBase* Base = *BasePtr;
-			const TSharedPtr<PCGExData::IDataValue>& Val = VT.Value;
-
-#define PCGEX_SET_VALUE_TAG_ATTR(_TYPE, _NAME) static_cast<FPCGMetadataAttribute<_TYPE>*>(Base)->SetValue(Entry, Val->GetValue<_TYPE>());
-			PCGEX_EXECUTEWITHRIGHTTYPE(Val->GetTypeId(), PCGEX_SET_VALUE_TAG_ATTR)
-#undef PCGEX_SET_VALUE_TAG_ATTR
-		}
-	}
-
-	// Creates value-tag attributes from Registry, then writes one row per parsed actor.
-	// Parsed and Entries are parallel arrays; Entries[i] receives the attributes from Parsed[i].
-	static void EmitValueTagAttributes(
-		UPCGMetadata* Meta,
-		const FValueTagRegistry& Registry,
-		TConstArrayView<FParsedActorTags> Parsed,
-		const TPCGValueRange<int64>& MetaEntries)
-	{
-		if (Parsed.IsEmpty() || Registry.TypeMap.IsEmpty())
-		{
-			return;
-		}
-		const TMap<FName, FPCGMetadataAttributeBase*> AttrMap = CreateValueTagAttributes(Meta, Registry);
-		if (AttrMap.IsEmpty())
-		{
-			return;
-		}
-		for (int32 i = 0; i < Parsed.Num(); ++i)
-		{
-			SetValueTagAttributes(AttrMap, MetaEntries[i], Parsed[i]);
-		}
-	}
-}
-
 bool UPCGExDefaultLevelDataExporter::ExportLevelData_Implementation(UWorld* World, UPCGDataAsset* OutAsset)
 {
 	FPCGExLevelExportContext EmptyContext;
 	return ExportLevelData(FPCGExLevelExportSource::FromWorld(World), OutAsset, EmptyContext);
+}
+
+#if WITH_EDITOR
+
+namespace PCGExDefaultLevelDataExporter
+{
+	FName SlotForClassification(const EPCGExActorExportType Type)
+	{
+		switch (Type)
+		{
+		case EPCGExActorExportType::Mesh: return PCGExLevelExport::Slots::Meshes;
+		case EPCGExActorExportType::Actor: return PCGExLevelExport::Slots::Actors;
+		case EPCGExActorExportType::Level: return PCGExLevelExport::Slots::Levels;
+		case EPCGExActorExportType::Skip: return NAME_None;
+		default:
+			ensureMsgf(false, TEXT("Unhandled EPCGExActorExportType"));
+			return NAME_None;
+		}
+	}
 }
 
 bool UPCGExDefaultLevelDataExporter::ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
@@ -712,32 +134,47 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(const FPCGExLevelExportSour
 		return false;
 	}
 
-	// The exporter never builds inline embedded mesh/level collections, never writes
-	// Tag_EntryIdx, and never emplaces the CollectionMap pin. It captures mesh + level
-	// contributions through OutContext (when pointers are non-null) and leaves final
-	// compaction + hashing to the caller -- typically
-	// UPCGExPCGDataAssetCollection::CompactSharedMesh / CompactSharedLevel /
-	// RebuildCollectionMaps. The 2-arg BP-facing path delegates here with an empty
-	// context; in that case the asset is produced without hashes (raw attributes only).
+	// Never writes Tag_EntryIdx for shared slots and never emplaces the CollectionMap pin: shared
+	// entries are handed back as captures and the caller's compaction resolves final indices. Per-entry
+	// slots are built and hashed here (they have no cross-entry mutualization story).
 
-	// Move any previous inner subobjects to the transient package so they get GC'd
-	// instead of being saved as orphan exports in the collection's .uasset. Otherwise,
-	// each rebuild accumulates dead sub-collections/point-data that can confuse save-time
-	// pointer traversal (observed as INT_MAX-pointer crashes during level save).
+	// Move any previous inner subobjects to the transient package so they get GC'd instead of being
+	// saved as orphan exports in the collection's .uasset -- accumulated dead inners have crashed
+	// save-time pointer traversal.
 	{
 		TArray<UObject*> OldInners;
 		GetObjectsWithOuter(OutAsset, OldInners, EGetObjectsFlags::None);
 		for (UObject* Inner : OldInners)
 		{
-			Inner->Rename(nullptr, GetTransientPackage(),
-			              REN_DontCreateRedirectors | REN_NonTransactional);
+			Inner->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors | REN_NonTransactional);
 		}
 	}
 
-	using namespace PCGExDefaultLevelDataExporterInternal;
+	using namespace PCGExDefaultLevelDataExporter;
 
-	// Phase 1: Collect and classify qualifying actors
-	TArray<FClassifiedActor> ClassifiedActors;
+	TArray<PCGExLevelExport::FHandlerRegistration> Registrations;
+	PCGExLevelExport::FHandlerRegistry::Get().GetRegistrations(Registrations);
+	if (!bUseRegisteredHandlers)
+	{
+		Registrations.RemoveAll([](const PCGExLevelExport::FHandlerRegistration& R) { return !PCGExLevelExport::IsBuiltinHandlerClass(R.HandlerClass); });
+	}
+
+	TArray<const UPCGExLevelExportHandler*> Handlers;
+	Handlers.Reserve(Registrations.Num());
+	for (const PCGExLevelExport::FHandlerRegistration& Registration : Registrations)
+	{
+		Handlers.Add(Registration.HandlerClass->GetDefaultObject<UPCGExLevelExportHandler>());
+	}
+
+	// Claim pass. The root is a candidate too (handlers may harvest its components) but never an entry.
+	TArray<FPCGExExportCandidate> Candidates;
+	if (Source.Root)
+	{
+		FPCGExExportCandidate& Root = Candidates.AddDefaulted_GetRef();
+		Root.Actor = Source.Root;
+		Root.bIsRoot = true;
+	}
+
 	for (AActor* Actor : Source.Actors)
 	{
 		if (!Actor || !UPCGExActorContentFilter::StaticPassesFilter(ContentFilter, Actor))
@@ -745,776 +182,308 @@ bool UPCGExDefaultLevelDataExporter::ExportLevelData(const FPCGExLevelExportSour
 			continue;
 		}
 
-		FClassifiedActor Classified;
-		Classified.Actor = Actor;
-		Classified.Type = ClassifyActor(Actor);
-
-		if (Classified.Type != EPCGExActorExportType::Skip)
+		FName ClaimedSlot = NAME_None;
+		for (int32 i = 0; i < Handlers.Num(); i++)
 		{
-			ClassifiedActors.Add(Classified);
+			if (Handlers[i]->Claim(Actor, Source, this))
+			{
+				ClaimedSlot = Registrations[i].Desc.SlotId;
+				break;
+			}
 		}
+		if (ClaimedSlot.IsNone())
+		{
+			ClaimedSlot = SlotForClassification(ClassifyActor(Actor));
+			if (ClaimedSlot.IsNone())
+			{
+				continue;
+			}
+		}
+
+		FPCGExExportCandidate& Candidate = Candidates.AddDefaulted_GetRef();
+		Candidate.Actor = Actor;
+		Candidate.ClaimedSlot = ClaimedSlot;
 	}
 
-	if (ClassifiedActors.IsEmpty())
+	if (Candidates.IsEmpty())
 	{
 		return false;
 	}
 
-	// Separate by type
-	TArray<FClassifiedActor> MeshActors;
-	TArray<FClassifiedActor> ActorActors;
-	TArray<FClassifiedActor> LevelActors;
-
-	for (const FClassifiedActor& CA : ClassifiedActors)
+	// Harvest pass: every handler sees every candidate.
+	TArray<TUniquePtr<FPCGExExportSlotWriter>> Writers;
+	Writers.Reserve(Registrations.Num());
+	for (int32 i = 0; i < Registrations.Num(); i++)
 	{
-		if (CA.Type == EPCGExActorExportType::Mesh)
+		const PCGExLevelExport::FHandlerRegistration& Registration = Registrations[i];
+		FPCGExExportSlotWriter& Writer = *Writers.Add_GetRef(MakeUnique<FPCGExExportSlotWriter>(Registration.Desc));
+
+		for (const FPCGExExportCandidate& Candidate : Candidates)
 		{
-			MeshActors.Add(CA);
+			Handlers[i]->Collect(Candidate, Source, this, Writer);
 		}
-		else if (CA.Type == EPCGExActorExportType::Actor)
+
+		// Shared captures live under the caller's outer (the host collection); per-entry collections under
+		// the exported asset. Instanced subobjects a handler minted must follow, or they cross packages
+		// once the exported asset is externalized. The writer is their sole owner, so they are moved.
+		UObject* EntryOuter = (Registration.Desc.Scope == EPCGExExportSlotScope::Shared && OutContext.CaptureOuter) ? OutContext.CaptureOuter : OutAsset;
+		Handlers[i]->FinalizeSlot(Writer, EntryOuter, this);
+		for (FInstancedStruct& Entry : Writer.Entries)
 		{
-			ActorActors.Add(CA);
-		}
-		else if (CA.Type == EPCGExActorExportType::Level)
-		{
-			LevelActors.Add(CA);
+			PCGExCollectionHelpers::ReparentInstancedSubobjects(Registration.Desc.EntryStruct, Entry.GetMutableMemory(), EntryOuter);
 		}
 	}
 
-	// Group level instances by their referenced UWorld asset path.
-	TMap<FSoftObjectPath, FLevelInfo> LevelInfoMap;
-	for (const FClassifiedActor& CA : LevelActors)
+	// Emit one point data per non-empty slot, in handler order.
+	TArray<UPCGBasePointData*> SlotPointData;
+	SlotPointData.Init(nullptr, Registrations.Num());
+	for (int32 i = 0; i < Registrations.Num(); i++)
 	{
-		const ALevelInstance* LI = Cast<ALevelInstance>(CA.Actor);
-		if (!LI)
+		if (!Writers[i]->IsEmpty())
 		{
-			continue;
-		}
-		const FSoftObjectPath LevelPath = LI->GetWorldAsset().ToSoftObjectPath();
-		if (LevelPath.IsNull())
-		{
-			continue;
-		}
-		LevelInfoMap.FindOrAdd(LevelPath).Count++;
-	}
-
-	// Parse actor value tags before the intersection loop so PlainTags/ValueTags are available.
-	// ActorParsedTags is parallel to ActorActors (same index); empty when NoParsing.
-	FValueTagRegistry ActorValueRegistry;
-	TArray<FParsedActorTags> ActorParsedTags;
-
-	if (ValueTagMode != EPCGExValueTagMode::NoParsing && !ActorActors.IsEmpty())
-	{
-		ActorParsedTags.Reserve(ActorActors.Num());
-		for (const FClassifiedActor& CA : ActorActors)
-		{
-			ActorParsedTags.Add(ParseActorTags(CA.Actor, ActorValueRegistry));
+			SlotPointData[i] = EmitSlotPoints(*Writers[i], Handlers[i], OutAsset);
 		}
 	}
 
-	// Compute actor tag intersections and property deltas for collection building
-	TMap<FActorInstanceKey, FActorClassInfo> ActorClassInfoMap;
-	for (int32 i = 0; i < ActorActors.Num(); i++)
-	{
-		FClassifiedActor& CA = ActorActors[i];
-
-		TArray<uint8> DeltaBytes;
-		TArray<FSoftObjectPath> DeltaCollaterals;
-		uint32 DeltaHash = 0;
-		if (bCapturePropertyDeltas && bGenerateCollections)
-		{
-			DeltaBytes = PCGExActorDelta::SerializeActorDelta(CA.Actor, &DeltaCollaterals);
-			DeltaHash = PCGExActorDelta::HashDelta(DeltaBytes);
-		}
-		CA.DeltaHash = DeltaHash;
-
-		FActorInstanceKey Key;
-		Key.ClassPath = FSoftClassPath(CA.Actor->GetClass());
-		Key.DeltaHash = DeltaHash;
-
-		FActorClassInfo& Info = ActorClassInfoMap.FindOrAdd(Key);
-		Info.Count++;
-
-		// Build the effective tag set for intersection based on the parsing mode.
-		// Raw Actor->Tags are still used for property deltas (kept as-is).
-		auto BuildEffectiveTags = [&]() -> TSet<FName>
-		{
-			TSet<FName> Tags;
-			if (ActorParsedTags.IsValidIndex(i))
-			{
-				const FParsedActorTags& Parsed = ActorParsedTags[i];
-				for (const FName& Tag : Parsed.PlainTags)
-				{
-					Tags.Add(Tag);
-				}
-				if (ValueTagMode == EPCGExValueTagMode::ParseAndKeep)
-				{
-					for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
-					{
-						Tags.Add(VT.Key);
-					}
-				}
-			}
-			else
-			{
-				for (const FName& Tag : CA.Actor->Tags)
-				{
-					Tags.Add(Tag);
-				}
-			}
-			return Tags;
-		};
-
-		if (Info.bFirstActor)
-		{
-			Info.bFirstActor = false;
-			if (!DeltaBytes.IsEmpty())
-			{
-				Info.SerializedDelta = MoveTemp(DeltaBytes);
-				Info.CollateralPaths = MoveTemp(DeltaCollaterals);
-			}
-			Info.IntersectedTags = BuildEffectiveTags();
-			Info.RepresentativeActor = CA.Actor;
-		}
-		else
-		{
-			Info.IntersectedTags = Info.IntersectedTags.Intersect(BuildEffectiveTags());
-		}
-	}
-
-	// Phase 2: Create typed point data
-
-	TArray<FMeshPoint> AllMeshPoints;
-	TMap<FMeshEntryKey, FMeshInfo> MeshInfoMap;
-	TMap<AActor*, FActorPropertySchemaCache> PropertySchemaCache;
-
-	for (const FClassifiedActor& CA : MeshActors)
-	{
-		ExtractMeshPointsFromActor(CA.Actor, Source, bCaptureMaterialOverrides, AllMeshPoints, MeshInfoMap, PropertySchemaCache);
-	}
-
-	// Create mesh point data
-	UPCGBasePointData* MeshPointData = nullptr;
-	if (!AllMeshPoints.IsEmpty())
-	{
-		// Parse value tags for each unique source actor (ISM actors may share the same actor).
-		FValueTagRegistry MeshValueRegistry;
-		TMap<AActor*, int32> MeshActorParsedTagIdx;
-		TArray<FParsedActorTags> MeshActorParsedTagsList;
-
-		if (ValueTagMode != EPCGExValueTagMode::NoParsing)
-		{
-			for (const FMeshPoint& Point : AllMeshPoints)
-			{
-				if (Point.SourceActor && !MeshActorParsedTagIdx.Contains(Point.SourceActor))
-				{
-					const int32 Idx = MeshActorParsedTagsList.Num();
-					MeshActorParsedTagIdx.Add(Point.SourceActor, Idx);
-					MeshActorParsedTagsList.Add(ParseActorTags(Point.SourceActor, MeshValueRegistry));
-				}
-			}
-		}
-
-		TPCGValueRange<FTransform> Transforms;
-		TPCGValueRange<FVector> BMin, BMax;
-		MeshPointData = CreatePointData(OutAsset, AllMeshPoints.Num(), Transforms, BMin, BMax);
-
-		for (int32 i = 0; i < AllMeshPoints.Num(); i++)
-		{
-			const FMeshPoint& Point = AllMeshPoints[i];
-			Transforms[i] = Point.Transform;
-			BMin[i] = Point.BoundsMin;
-			BMax[i] = Point.BoundsMax;
-		}
-
-		InitMetadata(MeshPointData, AllMeshPoints.Num());
-
-		UPCGMetadata* Meta = MeshPointData->MutableMetadata();
-		TPCGValueRange<int64> MetaEntries = MeshPointData->GetMetadataEntryValueRange();
-
-		TMap<FName, FPCGMetadataAttributeBase*> MeshValueTagAttrMap;
-		if (!MeshActorParsedTagsList.IsEmpty())
-		{
-			MeshValueTagAttrMap = CreateValueTagAttributes(Meta, MeshValueRegistry);
-		}
-
-		FPCGMetadataAttribute<FString>* ActorNameAttr = Meta->CreateAttribute<FString>(TEXT("ActorName"), FString(), false, true);
-
-		if (!bGenerateCollections)
-		{
-			FPCGMetadataAttribute<FSoftObjectPath>* MeshAttr = Meta->CreateAttribute<FSoftObjectPath>(TEXT("Mesh"), FSoftObjectPath(), false, true);
-
-			for (int32 i = 0; i < AllMeshPoints.Num(); i++)
-			{
-				const int64 Entry = MetaEntries[i];
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(Entry, AllMeshPoints[i].SourceActor->GetActorNameOrLabel());
-				}
-				if (MeshAttr)
-				{
-					MeshAttr->SetValue(Entry, AllMeshPoints[i].EntryKey.MeshPath);
-				}
-			}
-		}
-		else
-		{
-			for (int32 i = 0; i < AllMeshPoints.Num(); i++)
-			{
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(MetaEntries[i], AllMeshPoints[i].SourceActor->GetActorNameOrLabel());
-				}
-			}
-		}
-
-		if (!MeshValueTagAttrMap.IsEmpty())
-		{
-			for (int32 i = 0; i < AllMeshPoints.Num(); i++)
-			{
-				if (const int32* PIdx = MeshActorParsedTagIdx.Find(AllMeshPoints[i].SourceActor))
-				{
-					SetValueTagAttributes(MeshValueTagAttrMap, MetaEntries[i], MeshActorParsedTagsList[*PIdx]);
-				}
-			}
-		}
-
-		FPCGTaggedData& TaggedData = OutAsset->Data.TaggedData.Emplace_GetRef();
-		TaggedData.Data = MeshPointData;
-		TaggedData.Pin = PCGExCollections::Labels::MeshesPin;
-	}
-
-	// --- Actors ---
-	UPCGBasePointData* ActorPointData = nullptr;
-	if (!ActorActors.IsEmpty())
-	{
-		TPCGValueRange<FTransform> Transforms;
-		TPCGValueRange<FVector> BMin, BMax;
-		ActorPointData = CreatePointData(OutAsset, ActorActors.Num(), Transforms, BMin, BMax);
-
-		for (int32 i = 0; i < ActorActors.Num(); i++)
-		{
-			WriteActorTransformAndBounds(ActorActors[i].Actor, i, Source, BoundsEvaluator, Transforms, BMin, BMax);
-		}
-
-		InitMetadata(ActorPointData, ActorActors.Num());
-
-		UPCGMetadata* Meta = ActorPointData->MutableMetadata();
-		TPCGValueRange<int64> MetaEntries = ActorPointData->GetMetadataEntryValueRange();
-
-		FPCGMetadataAttribute<FString>* ActorNameAttr = Meta->CreateAttribute<FString>(TEXT("ActorName"), FString(), false, true);
-
-		if (!bGenerateCollections)
-		{
-			FPCGMetadataAttribute<FSoftClassPath>* ActorClassAttr = Meta->CreateAttribute<FSoftClassPath>(TEXT("ActorClass"), FSoftClassPath(), false, true);
-
-			for (int32 i = 0; i < ActorActors.Num(); i++)
-			{
-				const int64 Entry = MetaEntries[i];
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(Entry, ActorActors[i].Actor->GetActorNameOrLabel());
-				}
-				if (ActorClassAttr)
-				{
-					ActorClassAttr->SetValue(Entry, FSoftClassPath(ActorActors[i].Actor->GetClass()));
-				}
-			}
-		}
-		else
-		{
-			for (int32 i = 0; i < ActorActors.Num(); i++)
-			{
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(MetaEntries[i], ActorActors[i].Actor->GetActorNameOrLabel());
-				}
-			}
-		}
-
-		EmitValueTagAttributes(Meta, ActorValueRegistry, ActorParsedTags, MetaEntries);
-
-		// Write per-actor tag names as a joined string. Only meaningful in NoParsing and ParseAndKeep
-		// modes; in Parse mode all tags are already written as typed attributes above.
-		if (bWriteInstanceTags && InstanceTagsAttributeName != NAME_None && ValueTagMode != EPCGExValueTagMode::Parse)
-		{
-			if (FPCGMetadataAttribute<FString>* InstanceTagsAttr = Meta->CreateAttribute<FString>(InstanceTagsAttributeName, FString(), false, true))
-			{
-				for (int32 i = 0; i < ActorActors.Num(); i++)
-				{
-					FString TagsStr;
-
-					if (ValueTagMode == EPCGExValueTagMode::NoParsing)
-					{
-						for (const FName& Tag : ActorActors[i].Actor->Tags)
-						{
-							if (!TagsStr.IsEmpty())
-							{
-								TagsStr += TEXT(",");
-							}
-							TagsStr += Tag.ToString();
-						}
-					}
-					else if (ActorParsedTags.IsValidIndex(i)) // ParseAndKeep: plain tag names + value-tag name-parts
-					{
-						const FParsedActorTags& Parsed = ActorParsedTags[i];
-						for (const FName& Tag : Parsed.PlainTags)
-						{
-							if (!TagsStr.IsEmpty())
-							{
-								TagsStr += TEXT(",");
-							}
-							TagsStr += Tag.ToString();
-						}
-						for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
-						{
-							if (!TagsStr.IsEmpty())
-							{
-								TagsStr += TEXT(",");
-							}
-							TagsStr += VT.Key.ToString();
-						}
-					}
-
-					if (!TagsStr.IsEmpty())
-					{
-						InstanceTagsAttr->SetValue(MetaEntries[i], TagsStr);
-					}
-				}
-			}
-		}
-
-		FPCGTaggedData& TaggedData = OutAsset->Data.TaggedData.Emplace_GetRef();
-		TaggedData.Data = ActorPointData;
-		TaggedData.Pin = PCGExCollections::Labels::ActorsPin;
-	}
-
-	// --- Levels (nested level instances) ---
-	UPCGBasePointData* LevelPointData = nullptr;
-	if (!LevelActors.IsEmpty())
-	{
-		FValueTagRegistry LevelValueRegistry;
-		TArray<FParsedActorTags> LevelParsedTags;
-
-		if (ValueTagMode != EPCGExValueTagMode::NoParsing)
-		{
-			LevelParsedTags.Reserve(LevelActors.Num());
-			for (const FClassifiedActor& CA : LevelActors)
-			{
-				LevelParsedTags.Add(ParseActorTags(CA.Actor, LevelValueRegistry));
-			}
-		}
-
-		TPCGValueRange<FTransform> Transforms;
-		TPCGValueRange<FVector> BMin, BMax;
-		LevelPointData = CreatePointData(OutAsset, LevelActors.Num(), Transforms, BMin, BMax);
-
-		for (int32 i = 0; i < LevelActors.Num(); i++)
-		{
-			WriteActorTransformAndBounds(LevelActors[i].Actor, i, Source, BoundsEvaluator, Transforms, BMin, BMax);
-		}
-
-		InitMetadata(LevelPointData, LevelActors.Num());
-
-		UPCGMetadata* Meta = LevelPointData->MutableMetadata();
-		TPCGValueRange<int64> MetaEntries = LevelPointData->GetMetadataEntryValueRange();
-
-		FPCGMetadataAttribute<FString>* ActorNameAttr = Meta->CreateAttribute<FString>(TEXT("ActorName"), FString(), false, true);
-
-		if (!bGenerateCollections)
-		{
-			FPCGMetadataAttribute<FSoftObjectPath>* LevelAssetAttr = Meta->CreateAttribute<FSoftObjectPath>(TEXT("LevelAsset"), FSoftObjectPath(), false, true);
-
-			for (int32 i = 0; i < LevelActors.Num(); i++)
-			{
-				const int64 Entry = MetaEntries[i];
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(Entry, LevelActors[i].Actor->GetActorNameOrLabel());
-				}
-				if (LevelAssetAttr)
-				{
-					if (const ALevelInstance* LI = Cast<ALevelInstance>(LevelActors[i].Actor))
-					{
-						LevelAssetAttr->SetValue(Entry, LI->GetWorldAsset().ToSoftObjectPath());
-					}
-				}
-			}
-		}
-		else
-		{
-			for (int32 i = 0; i < LevelActors.Num(); i++)
-			{
-				if (ActorNameAttr)
-				{
-					ActorNameAttr->SetValue(MetaEntries[i], LevelActors[i].Actor->GetActorNameOrLabel());
-				}
-			}
-		}
-
-		EmitValueTagAttributes(Meta, LevelValueRegistry, LevelParsedTags, MetaEntries);
-
-		FPCGTaggedData& TaggedData = OutAsset->Data.TaggedData.Emplace_GetRef();
-		TaggedData.Data = LevelPointData;
-		TaggedData.Pin = PCGExCollections::Labels::LevelsPin;
-	}
-
-	// Phase 2.5: Notify subclasses
 	OnExportComplete(OutAsset);
 
-	// Phase 3: Collection-flavored capture (when bGenerateCollections).
-	// Builds the in-memory mesh + level entry lists and the per-entry actor collection,
-	// then assigns local-pick indices to each point. No inline shared collections are
-	// built, no Tag_EntryIdx attribute is written, and no CollectionMap pin is emplaced
-	// here -- those are the caller's responsibility (see UPCGExPCGDataAssetCollection
-	// shared-collection API). The per-entry actor collection IS built here because it
-	// has no cross-entry mutualization story.
 	if (bGenerateCollections)
 	{
-		// Build the mesh entry list. MeshInfoMap.EntryIndex is assigned here so the local-pick
-		// write below can map (MeshPath → local entry index) consistently.
-		TArray<FPCGExMeshCollectionEntry> MeshEntries;
-		if (!MeshInfoMap.IsEmpty())
+		for (int32 i = 0; i < Registrations.Num(); i++)
 		{
-			MeshEntries.SetNum(MeshInfoMap.Num());
-			int32 MeshIdx = 0;
-			for (auto& Elem : MeshInfoMap)
+			const PCGExLevelExport::FHandlerRegistration& Registration = Registrations[i];
+			FPCGExExportSlotWriter& Writer = *Writers[i];
+			if (Writer.IsEmpty() || !SlotPointData[i])
 			{
-				Elem.Value.EntryIndex = MeshIdx;
-
-				FPCGExMeshCollectionEntry& MeshEntry = MeshEntries[MeshIdx];
-				MeshEntry.StaticMesh = TSoftObjectPtr<UStaticMesh>(Elem.Key.MeshPath);
-				MeshEntry.Weight = Elem.Value.TotalCount;
-				// Carry the per-bucket property-component identity onto the entry so
-				// CompactSharedMesh dedup honors it.
-				MeshEntry.PropertyComponentHash = Elem.Key.PropertyComponentHash;
-
-				if (Elem.Key.bIsISMSource)
-				{
-					MeshEntry.ISMDescriptor = Elem.Value.ISMDescriptor;
-				}
-				else
-				{
-					MeshEntry.SMDescriptor = Elem.Value.SMDescriptor;
-				}
-
-				// Material variants
-				if (bCaptureMaterialOverrides && !Elem.Value.UniqueVariantMaterials.IsEmpty())
-				{
-					MeshEntry.MaterialVariants = EPCGExMaterialVariantsMode::Multi;
-
-					for (const TArray<FSoftObjectPath>& VariantMats : Elem.Value.UniqueVariantMaterials)
-					{
-						FPCGExMaterialOverrideCollection& Variant = MeshEntry.MaterialOverrideVariantsList.AddDefaulted_GetRef();
-						Variant.Weight = 1;
-
-						for (int32 SlotIdx = 0; SlotIdx < VariantMats.Num(); SlotIdx++)
-						{
-							FPCGExMaterialOverrideEntry& MatEntry = Variant.Overrides.AddDefaulted_GetRef();
-							MatEntry.SlotIndex = SlotIdx;
-							MatEntry.Material = TSoftObjectPtr<UMaterialInterface>(VariantMats[SlotIdx]);
-						}
-					}
-				}
-
-				// Pull property-component values from the representative actor and stage them
-				// onto the mesh entry's PropertyOverrides. CompactSharedMesh preserves these
-				// across cross-entry aggregation; the SharedMeshCollection's CollectionProperties
-				// is rebuilt from the union of all entries' overrides afterwards via
-				// RefreshCollectionPropertiesFromEntries.
-				//
-				// Read from the schema cache populated during the per-actor mesh-extract loop --
-				// the representative actor was hashed there, so its Resolved schema is already
-				// computed. Fall back to a fresh extract for the (rare) bucket without one (shouldn't
-				// happen for property-bearing actors, but the cache is non-authoritative).
-				const TArray<FInstancedStruct>* Authored = nullptr;
-				TArray<FInstancedStruct> FallbackAuthored;
-				if (const FActorPropertySchemaCache* Cached = PropertySchemaCache.Find(Elem.Value.RepresentativeActor.Get()))
-				{
-					Authored = &Cached->Resolved;
-				}
-				else
-				{
-					FallbackAuthored = UPCGExPropertyCollectionComponent::ExtractSchemaFromActor(
-						Elem.Value.RepresentativeActor.Get());
-					Authored = &FallbackAuthored;
-				}
-
-				if (!Authored->IsEmpty())
-				{
-					MeshEntry.PropertyOverrides.Overrides.Reset(Authored->Num());
-					for (const FInstancedStruct& Prop : *Authored)
-					{
-						// Seed outer identity from inner so the entry ships in canonical
-						// SyncToSchema shape; first reconcile would otherwise migrate it.
-						FPCGExPropertyOverrideEntry& Slot = MeshEntry.PropertyOverrides.Overrides.AddDefaulted_GetRef();
-						Slot.Value = Prop;
-						Slot.bEnabled = true;
-#if WITH_EDITORONLY_DATA
-						Slot.SeedOuterIdentityFromInner();
-#endif
-					}
-				}
-
-				MeshIdx++;
-			}
-		}
-
-		// Build the level entry list. LevelInfoMap.EntryIndex is assigned here so the
-		// local-pick write below can map (LevelPath → local entry index) consistently.
-		TArray<FPCGExLevelCollectionEntry> LevelEntries;
-		if (!LevelInfoMap.IsEmpty())
-		{
-			LevelEntries.SetNum(LevelInfoMap.Num());
-			int32 LevelIdx = 0;
-			for (auto& Elem : LevelInfoMap)
-			{
-				Elem.Value.EntryIndex = LevelIdx;
-
-				FPCGExLevelCollectionEntry& LevelEntry = LevelEntries[LevelIdx];
-				LevelEntry.Level = TSoftObjectPtr<UWorld>(Elem.Key);
-				LevelEntry.Weight = Elem.Value.Count;
-
-				LevelIdx++;
-			}
-		}
-
-		// Build the per-entry actor collection (no cross-entry mutualization).
-		UPCGExActorCollection* EmbeddedActorCollection = nullptr;
-
-		if (!ActorClassInfoMap.IsEmpty())
-		{
-			// EntryIds re-claimed by actor identity: exact = class + property-delta hash,
-			// loose = class alone (survives a delta change). Unclaimed entries get fresh ids
-			// from the RebuildStagingData -> SyncEntryIds pass.
-			PCGExAssetCollection::FEntryIdBank PreservedIds;
-
-			// Reuse the previous collection UObject -- a fresh one would mint a new
-			// CollectionGUID on every export, unbinding external references (variants).
-			if (UPCGExActorCollection* Previous = OutContext.PreviousActorCollection)
-			{
-				for (const FPCGExActorCollectionEntry& PrevEntry : Previous->Entries)
-				{
-					// Rebuilt as an FActorInstanceKey so deposit and claim share one key derivation.
-					FActorInstanceKey PrevKey;
-					PrevKey.ClassPath = FSoftClassPath(PrevEntry.Actor.ToString());
-					PrevKey.DeltaHash = PCGExActorDelta::HashDelta(PrevEntry.SerializedPropertyDelta);
-					PreservedIds.Deposit(GetTypeHash(PrevKey), GetTypeHash(PrevKey.ClassPath), PrevEntry.EntryId);
-				}
-
-				Previous->Rename(nullptr, OutAsset, REN_DontCreateRedirectors | REN_NonTransactional);
-				// InitNumEntries SetNums without clearing -- shrink would leave stale survivors.
-				Previous->Entries.Reset();
-				EmbeddedActorCollection = Previous;
-			}
-			else
-			{
-				EmbeddedActorCollection = NewObject<UPCGExActorCollection>(OutAsset);
+				continue;
 			}
 
-			EmbeddedActorCollection->InitNumEntries(ActorClassInfoMap.Num());
-
-			// Parallel to Entries: one live donor per entry, used by the property-component scan
-			// below. The bucket's RepresentativeActor was captured at the same point we captured
-			// SerializedDelta, so the scan reads from the actor whose authored state the delta
-			// already reflects.
-			TArray<AActor*> RepresentativeInstances;
-			RepresentativeInstances.Init(nullptr, ActorClassInfoMap.Num());
-
-			int32 ActorIdx = 0;
-			for (auto& Elem : ActorClassInfoMap)
+			if (Registration.Desc.Scope == EPCGExExportSlotScope::PerEntry)
 			{
-				Elem.Value.EntryIndex = ActorIdx;
-
-				FPCGExActorCollectionEntry& ActorEntry = EmbeddedActorCollection->Entries[ActorIdx];
-				ActorEntry.Actor = TSoftClassPtr<AActor>(Elem.Key.ClassPath);
-				ActorEntry.Weight = Elem.Value.Count;
-				ActorEntry.Tags = Elem.Value.IntersectedTags;
-
-				if (!Elem.Value.SerializedDelta.IsEmpty())
-				{
-					ActorEntry.SerializedPropertyDelta = Elem.Value.SerializedDelta;
-					ActorEntry.DeltaCollateralPaths = Elem.Value.CollateralPaths;
-				}
-
-				ActorEntry.EntryId = PreservedIds.ClaimExact(GetTypeHash(Elem.Key));
-
-				RepresentativeInstances[ActorIdx] = Elem.Value.RepresentativeActor.Get();
-
-				ActorIdx++;
+				BuildEmbeddedSlot(Registration, Writer, OutAsset, SlotPointData[i], OutContext);
+				continue;
 			}
 
-			// Loose pass -- strictly after every exact claim; class path mirrors the deposit's loose key.
-			for (FPCGExActorCollectionEntry& ActorEntry : EmbeddedActorCollection->Entries)
+			if (!OutContext.Captures)
 			{
-				if (ActorEntry.EntryId == 0)
-				{
-					ActorEntry.EntryId = PreservedIds.ClaimLoose(GetTypeHash(ActorEntry.Actor.ToSoftObjectPath()));
-				}
+				continue;
 			}
 
-			// Scan UPCGExPropertyCollectionComponent on each representative actor and merge into
-			// the embedded collection's schema + per-entry overrides. Runs BEFORE RebuildStagingData
-			// so the staging pass observes the final schema; the non-editor RebuildStagingData
-			// variant does not fire EDITOR_OnPostStagingRebuild, so there is no double-scan from
-			// the UPCGExActorCollection auto-hook on this code path.
-			//
-			// The exporter's policy is also mirrored onto the embedded collection's own field so
-			// a user-triggered manual rebuild of the embedded asset uses the same policy that
-			// generated it.
-			EmbeddedActorCollection->SchemaMergePolicy = SchemaMergePolicy;
-			EmbeddedActorCollection->RebuildPropertiesFromActorComponents(
-				SchemaMergePolicy, RepresentativeInstances);
-
-			EmbeddedActorCollection->RebuildStagingData(true);
-		}
-
-		if (OutContext.ActorCollectionOut)
-		{
-			*OutContext.ActorCollectionOut = EmbeddedActorCollection;
-		}
-
-		// Capture per-mesh-point local picks (low 16 = local entry index, high 16 = sec+1).
-		// Tag_EntryIdx is left unwritten; the caller resolves shared indices and writes
-		// the final hashes during shared-collection compaction.
-		if (MeshPointData && !MeshEntries.IsEmpty() && OutContext.MeshLocalPicks)
-		{
-			TArray<int32>& LocalPicksOut = *OutContext.MeshLocalPicks;
-			LocalPicksOut.SetNumUninitialized(AllMeshPoints.Num());
-
-			for (int32 i = 0; i < AllMeshPoints.Num(); i++)
+			// Local picks (low 16 = local entry index, high 16 = sec+1). Tag_EntryIdx stays unwritten; the
+			// caller resolves shared indices during compaction.
+			FPCGExExportSlotCapture& Capture = PCGExExportSlots::FindOrAdd(*OutContext.Captures, Registration.Desc.SlotId);
+			Capture.LocalPicks.SetNumUninitialized(Writer.Items.Num());
+			for (int32 p = 0; p < Writer.Items.Num(); p++)
 			{
-				const FMeshPoint& Point = AllMeshPoints[i];
-				const FMeshInfo* Info = MeshInfoMap.Find(Point.EntryKey);
-				if (!Info)
+				const FPCGExExportItem& Item = Writer.Items[p];
+				if (Item.LocalEntryIndex < 0)
 				{
-					// Sentinel: -1 means "no pick" -- rewrite pass leaves the hash unwritten.
-					LocalPicksOut[i] = -1;
+					Capture.LocalPicks[p] = -1;
 					continue;
 				}
-
-				const int16 SecIdx = (bCaptureMaterialOverrides && Point.MaterialVariantIndex >= 0)
-					? static_cast<int16>(Point.MaterialVariantIndex)
-					: static_cast<int16>(-1);
-
-				LocalPicksOut[i] = FPCGExLevelExportContext::PackLocalPick(Info->EntryIndex, SecIdx);
+				const int16 Sec = Registration.Desc.bSupportsSecondary ? Item.SecondaryIndex : static_cast<int16>(-1);
+				Capture.LocalPicks[p] = FPCGExLevelExportContext::PackLocalPick(Item.LocalEntryIndex, Sec);
 			}
-		}
-
-		// Encode actor hashes inline -- actor collection is per-entry, so the hash is resolved
-		// here against EmbeddedActorCollection's own GUID. The caller does not rewrite actor
-		// hashes (the CollectionMap rebuild simply re-registers the same actor collection).
-		if (ActorPointData && EmbeddedActorCollection)
-		{
-			PCGExCollections::FPickPacker ActorPacker;
-			ActorPacker.RegisterCollection(EmbeddedActorCollection);
-
-			UPCGMetadata* Meta = ActorPointData->MutableMetadata();
-			TPCGValueRange<int64> MetaEntries = ActorPointData->GetMetadataEntryValueRange();
-
-			FPCGMetadataAttribute<int64>* EntryHashAttr = Meta->CreateAttribute<int64>(
-				PCGExCollections::Labels::Tag_EntryIdx, 0, false, true);
-
-			if (EntryHashAttr)
-			{
-				for (int32 i = 0; i < ActorActors.Num(); i++)
-				{
-					FActorInstanceKey Key;
-					Key.ClassPath = FSoftClassPath(ActorActors[i].Actor->GetClass());
-					Key.DeltaHash = ActorActors[i].DeltaHash;
-					const FActorClassInfo* Info = ActorClassInfoMap.Find(Key);
-					if (!Info)
-					{
-						continue;
-					}
-
-					const uint64 Hash = ActorPacker.GetPickIdx(EmbeddedActorCollection, static_cast<int16>(Info->EntryIndex), -1);
-					EntryHashAttr->SetValue(MetaEntries[i], static_cast<int64>(Hash));
-				}
-			}
-		}
-
-		// Capture per-level-point local picks (identity of local entry index, -1 sentinel).
-		if (LevelPointData && !LevelEntries.IsEmpty() && OutContext.LevelLocalPicks)
-		{
-			TArray<int32>& LocalPicksOut = *OutContext.LevelLocalPicks;
-			LocalPicksOut.SetNumUninitialized(LevelActors.Num());
-
-			for (int32 i = 0; i < LevelActors.Num(); i++)
-			{
-				const ALevelInstance* LI = Cast<ALevelInstance>(LevelActors[i].Actor);
-				if (!LI)
-				{
-					LocalPicksOut[i] = -1;
-					continue;
-				}
-				const FSoftObjectPath LevelPath = LI->GetWorldAsset().ToSoftObjectPath();
-				const FLevelInfo* Info = LevelInfoMap.Find(LevelPath);
-				if (!Info)
-				{
-					LocalPicksOut[i] = -1;
-					continue;
-				}
-
-				LocalPicksOut[i] = Info->EntryIndex;
-			}
-		}
-
-		// Compute the "common-ancestor" inherited-defaults view for the contributing actors:
-		// per property, the value all unique BP classes agree on at the CDO level (the
-		// BuildInheritedSchema chain walk WITHOUT instance overrides); when classes disagree,
-		// fall back to the asset's authored default. Consumed by CompactSharedMesh to seed the
-		// shared MeshCollection's CollectionProperties.
-		if (OutContext.MeshInheritedDefaults)
-		{
-			TMap<UClass*, TArray<FInstancedStruct>> InheritedByClass;
-			TMap<UClass*, TArray<FInstancedStruct>> AssetDefaultsByClass;
-			for (const TPair<AActor*, FActorPropertySchemaCache>& Pair : PropertySchemaCache)
-			{
-				AActor* Actor = Pair.Key;
-				if (!Actor)
-				{
-					continue;
-				}
-				UClass* Class = Actor->GetClass();
-				if (InheritedByClass.Contains(Class))
-				{
-					continue;
-				}
-				UPCGExPropertyCollectionComponent* Comp = UPCGExPropertyCollectionComponent::FindOnActor(Actor);
-				if (!Comp)
-				{
-					continue;
-				}
-				InheritedByClass.Add(Class, Comp->BuildInheritedSchema());
-				AssetDefaultsByClass.Add(Class, Comp->BuildAssetDefaultSchema());
-			}
-
-			TArray<TConstArrayView<FInstancedStruct>> InheritedViews;
-			InheritedViews.Reserve(InheritedByClass.Num());
-			for (const TPair<UClass*, TArray<FInstancedStruct>>& Pair : InheritedByClass)
-			{
-				InheritedViews.Emplace(Pair.Value);
-			}
-			TArray<TConstArrayView<FInstancedStruct>> AssetDefaultViews;
-			AssetDefaultViews.Reserve(AssetDefaultsByClass.Num());
-			for (const TPair<UClass*, TArray<FInstancedStruct>>& Pair : AssetDefaultsByClass)
-			{
-				AssetDefaultViews.Emplace(Pair.Value);
-			}
-			*OutContext.MeshInheritedDefaults = PCGExProperties::AggregateAgreedValuesByName(InheritedViews, AssetDefaultViews);
-		}
-
-		// Hand the captured mesh + level entry lists back to the caller for compaction.
-		if (OutContext.MeshContributions)
-		{
-			*OutContext.MeshContributions = MoveTemp(MeshEntries);
-		}
-		if (OutContext.LevelContributions)
-		{
-			*OutContext.LevelContributions = MoveTemp(LevelEntries);
+			Capture.Entries = MoveTemp(Writer.Entries);
+			Capture.InheritedDefaults = MoveTemp(Writer.InheritedDefaults);
 		}
 	}
 
 	return OutAsset->Data.TaggedData.Num() > 0;
 }
+
+UPCGBasePointData* UPCGExDefaultLevelDataExporter::EmitSlotPoints(const FPCGExExportSlotWriter& Writer, const UPCGExLevelExportHandler* Handler, UPCGDataAsset* OutAsset) const
+{
+	using namespace PCGExLevelExportShared;
+
+	const int32 NumPoints = Writer.Items.Num();
+
+	TPCGValueRange<FTransform> Transforms;
+	TPCGValueRange<FVector> BMin, BMax;
+	UPCGBasePointData* PointData = CreatePointData(OutAsset, NumPoints, Transforms, BMin, BMax);
+
+	for (int32 i = 0; i < NumPoints; i++)
+	{
+		const FPCGExExportItem& Item = Writer.Items[i];
+		Transforms[i] = Item.Transform;
+		BMin[i] = Item.BoundsMin;
+		BMax[i] = Item.BoundsMax;
+	}
+
+	InitMetadata(PointData, NumPoints);
+
+	UPCGMetadata* Meta = PointData->MutableMetadata();
+	TPCGValueRange<int64> MetaEntryRange = PointData->GetMetadataEntryValueRange();
+	TArray<int64> MetaEntries;
+	MetaEntries.SetNumUninitialized(NumPoints);
+	for (int32 i = 0; i < NumPoints; i++)
+	{
+		MetaEntries[i] = MetaEntryRange[i];
+	}
+
+	if (FPCGMetadataAttribute<FString>* ActorNameAttr = Meta->CreateAttribute<FString>(TEXT("ActorName"), FString(), false, true))
+	{
+		for (int32 i = 0; i < NumPoints; i++)
+		{
+			if (const AActor* SourceActor = Writer.Items[i].SourceActor)
+			{
+				ActorNameAttr->SetValue(MetaEntries[i], SourceActor->GetActorNameOrLabel());
+			}
+		}
+	}
+
+	// Value tags, parsed once per unique source actor (ISM actors contribute many points).
+	if (ValueTagMode != EPCGExValueTagMode::NoParsing)
+	{
+		FValueTagRegistry Registry;
+		TMap<const AActor*, int32> ParsedIndex;
+		TArray<FParsedActorTags> ParsedList;
+
+		for (const FPCGExExportItem& Item : Writer.Items)
+		{
+			if (Item.SourceActor && !ParsedIndex.Contains(Item.SourceActor))
+			{
+				ParsedIndex.Add(Item.SourceActor, ParsedList.Num());
+				ParsedList.Add(ParseActorTags(Item.SourceActor, &Registry));
+			}
+		}
+
+		if (!ParsedList.IsEmpty() && !Registry.TypeMap.IsEmpty())
+		{
+			const TMap<FName, FPCGMetadataAttributeBase*> AttrMap = CreateValueTagAttributes(Meta, Registry);
+			if (!AttrMap.IsEmpty())
+			{
+				for (int32 i = 0; i < NumPoints; i++)
+				{
+					if (const int32* Index = ParsedIndex.Find(Writer.Items[i].SourceActor))
+					{
+						SetValueTagAttributes(AttrMap, MetaEntries[i], ParsedList[*Index]);
+					}
+				}
+			}
+		}
+	}
+
+	Handler->WriteItemAttributes(Meta, MetaEntries, Writer, this);
+	if (!bGenerateCollections)
+	{
+		Handler->WriteRawAttributes(Meta, MetaEntries, Writer, this);
+	}
+
+	FPCGTaggedData& TaggedData = OutAsset->Data.TaggedData.Emplace_GetRef();
+	TaggedData.Data = PointData;
+	TaggedData.Pin = Writer.Desc.PinName;
+
+	return PointData;
+}
+
+void UPCGExDefaultLevelDataExporter::BuildEmbeddedSlot(const PCGExLevelExport::FHandlerRegistration& Registration, FPCGExExportSlotWriter& Writer, UPCGDataAsset* OutAsset, UPCGBasePointData* PointData, FPCGExLevelExportContext& OutContext) const
+{
+	const FPCGExExportSlotDesc& Desc = Registration.Desc;
+	const IPCGExExportSlotPolicy& Policy = *Registration.Policy;
+
+	// A caller without slot storage still gets hashes: the collection is an inner of the exported asset
+	// either way, only the hand-back is skipped.
+	TArray<FPCGExExportCollectionSlot> LocalSlots;
+	FPCGExExportCollectionSlot& Slot = PCGExExportSlots::FindOrAdd(OutContext.EmbeddedSlots ? *OutContext.EmbeddedSlots : LocalSlots, Desc.SlotId);
+
+	// EntryIds re-claimed by identity: exact = the policy's content hash, loose = its primary path (survives
+	// a content change). Unclaimed entries get fresh ids from the RebuildStagingData -> SyncEntryIds pass.
+	PCGExAssetCollection::FEntryIdBank PreservedIds;
+	UPCGExAssetCollection* Collection = Slot.Collection;
+
+	if (Collection && Collection->GetClass() != Desc.CollectionClass)
+	{
+		// A slot whose registered class changed cannot keep the object; ids are lost with it.
+		Collection->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors | REN_NonTransactional);
+		Collection = nullptr;
+	}
+
+	if (Collection)
+	{
+		// Reuse the previous object -- a fresh one would mint a new CollectionGUID on every export,
+		// unbinding external references (variants).
+		Collection->ForEachEntry([&PreservedIds, &Policy](const FPCGExAssetCollectionEntry* Entry, int32)
+		{
+			if (Entry)
+			{
+				PreservedIds.Deposit(Policy.Hash(*Entry), GetTypeHash(Policy.PrimaryPath(*Entry)), Entry->EntryId);
+			}
+		});
+
+		Collection->Rename(nullptr, OutAsset, REN_DontCreateRedirectors | REN_NonTransactional);
+
+		// Every index is rewritten below; only the previous entries' instanced subobjects need retiring.
+		Collection->ForEachEntry([&Desc](FPCGExAssetCollectionEntry* Entry, int32)
+		{
+			if (Entry)
+			{
+				PCGExCollectionHelpers::RetireInstancedSubobjects(Desc.EntryStruct, Entry);
+			}
+		});
+	}
+	else
+	{
+		Collection = NewObject<UPCGExAssetCollection>(OutAsset, Desc.CollectionClass);
+	}
+
+	const int32 NumEntries = Writer.Entries.Num();
+	Collection->InitNumEntries(NumEntries);
+	for (int32 i = 0; i < NumEntries; i++)
+	{
+		FPCGExAssetCollectionEntry* Dst = Collection->GetMutableEntryRaw(i);
+		Desc.EntryStruct->CopyScriptStruct(Dst, Writer.Entries[i].GetMemory());
+		// The writer's entries are the sole owners of what they minted: moved, not duplicated.
+		PCGExCollectionHelpers::ReparentInstancedSubobjects(Desc.EntryStruct, Dst, Collection);
+		Dst->EntryId = PreservedIds.ClaimExact(Policy.Hash(*Dst));
+	}
+
+	// Loose pass -- strictly after every exact claim.
+	for (int32 i = 0; i < NumEntries; i++)
+	{
+		FPCGExAssetCollectionEntry* Dst = Collection->GetMutableEntryRaw(i);
+		if (Dst->EntryId == 0)
+		{
+			Dst->EntryId = PreservedIds.ClaimLoose(GetTypeHash(Policy.PrimaryPath(*Dst)));
+		}
+	}
+
+	Registration.HandlerClass->GetDefaultObject<UPCGExLevelExportHandler>()->FinalizeEmbeddedCollection(Collection, Writer, this);
+	Collection->RebuildStagingData(true);
+
+	Slot.Collection = Collection;
+
+	// Hashes resolve against this collection's own GUID; the caller's map rebuild re-registers it as is.
+	PCGExCollections::FPickPacker Packer;
+	Packer.RegisterCollection(Collection);
+
+	UPCGMetadata* Meta = PointData->MutableMetadata();
+	TPCGValueRange<int64> MetaEntries = PointData->GetMetadataEntryValueRange();
+	FPCGMetadataAttribute<int64>* EntryHashAttr = Meta->CreateAttribute<int64>(PCGExCollections::Labels::Tag_EntryIdx, 0, false, true);
+	if (!EntryHashAttr)
+	{
+		return;
+	}
+
+	for (int32 i = 0; i < Writer.Items.Num(); i++)
+	{
+		const FPCGExExportItem& Item = Writer.Items[i];
+		if (Item.LocalEntryIndex < 0)
+		{
+			continue;
+		}
+		const int16 Sec = Desc.bSupportsSecondary ? Item.SecondaryIndex : static_cast<int16>(-1);
+		const uint64 Hash = Packer.GetPickIdx(Collection, static_cast<int16>(Item.LocalEntryIndex), Sec);
+		EntryHashAttr->SetValue(MetaEntries[i], static_cast<int64>(Hash));
+	}
+}
+
+#else
+
+bool UPCGExDefaultLevelDataExporter::ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
+{
+	// Level harvesting is an authoring operation; cooked data carries the baked result.
+	return false;
+}
+
+#endif

--- a/Source/PCGExCollections/Private/Helpers/PCGExLevelExportBuiltinHandlers.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExLevelExportBuiltinHandlers.cpp
@@ -1,0 +1,868 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "Helpers/PCGExLevelExportBuiltinHandlers.h"
+
+#if WITH_EDITOR
+
+#include "PCGExPropertyCollectionComponent.h"
+#include "PCGExSchemaMerging.h"
+#include "Collections/PCGExActorCollection.h"
+#include "Collections/PCGExLevelCollection.h"
+#include "Collections/PCGExMeshCollection.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Data/Descriptors/PCGExComponentDescriptors.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Helpers/PCGExActorPropertyDelta.h"
+#include "Helpers/PCGExCollectionSortKeys.h"
+#include "Helpers/PCGExDefaultLevelDataExporter.h"
+#include "Helpers/PCGExLevelExportShared.h"
+#include "ISMPartition/ISMComponentDescriptor.h"
+#include "LevelInstance/LevelInstanceActor.h"
+#include "Materials/MaterialInterface.h"
+#include "Metadata/PCGMetadata.h"
+#include "Serialization/ArchiveCrc32.h"
+#include "Serialization/StructuredArchive.h"
+
+#pragma region Mesh
+
+namespace PCGExMeshExportHandler
+{
+	// Components share an entry only when they agree on mesh, source kind, AND the descriptor
+	// fingerprint (every UPROPERTY except OverrideMaterials -- those become per-entry variants).
+	// PropertyComponentHash is folded in so two mesh actors that author distinct property-component
+	// values land in distinct entries.
+	struct FMeshEntryKey
+	{
+		FSoftObjectPath MeshPath;
+		uint32 DescriptorFingerprint = 0;
+		bool bIsISMSource = false;
+		uint32 PropertyComponentHash = 0;
+
+		bool operator==(const FMeshEntryKey& Other) const
+		{
+			return MeshPath == Other.MeshPath
+				&& DescriptorFingerprint == Other.DescriptorFingerprint
+				&& bIsISMSource == Other.bIsISMSource
+				&& PropertyComponentHash == Other.PropertyComponentHash;
+		}
+
+		friend uint32 GetTypeHash(const FMeshEntryKey& Key)
+		{
+			return HashCombine(
+				HashCombine(
+					HashCombine(GetTypeHash(Key.MeshPath), Key.DescriptorFingerprint),
+					Key.bIsISMSource ? 1u : 0u),
+				Key.PropertyComponentHash);
+		}
+	};
+
+	// Per-export cache of (Resolved schema, Hash) keyed by source actor. ExtractSchemaFromActor is the
+	// expensive step and its result is read twice per actor: to bucket by hash and to seed overrides.
+	struct FActorPropertySchemaCache
+	{
+		TArray<FInstancedStruct> Resolved;
+		uint32 Hash = 0;
+	};
+
+	struct FScratch final : FPCGExExportScratch
+	{
+		TMap<AActor*, FActorPropertySchemaCache> PropertySchemaCache;
+
+		// Parallel to the writer's entries.
+		TArray<FMeshEntryKey> Keys;
+		TArray<TMap<uint32, int32>> VariantHashToIndex;
+	};
+
+	// Hash is over the EFFECTIVE extracted schema (BP class chain + PreparePropertyValues), not raw
+	// component state -- a raw-state hash would collapse actors that resolve to different values.
+	const FActorPropertySchemaCache& GetOrComputeActorPropertySchema(AActor* Actor, TMap<AActor*, FActorPropertySchemaCache>& Cache)
+	{
+		if (const FActorPropertySchemaCache* Found = Cache.Find(Actor))
+		{
+			return *Found;
+		}
+		FActorPropertySchemaCache& Entry = Cache.Add(Actor);
+
+		if (!Actor || !UPCGExPropertyCollectionComponent::FindOnActor(Actor))
+		{
+			return Entry;
+		}
+
+		Entry.Resolved = UPCGExPropertyCollectionComponent::ExtractSchemaFromActor(Actor);
+		if (Entry.Resolved.IsEmpty())
+		{
+			return Entry;
+		}
+
+		FArchiveCrc32 Crc;
+		for (const FInstancedStruct& Prop : Entry.Resolved)
+		{
+			const UScriptStruct* ScriptStruct = Prop.GetScriptStruct();
+			if (!ScriptStruct)
+			{
+				continue;
+			}
+
+			// Type path prefix so two values of different types but matching byte layout don't alias.
+			FString TypeName = ScriptStruct->GetPathName();
+			Crc << TypeName;
+
+			const_cast<UScriptStruct*>(ScriptStruct)->SerializeItem(
+				FStructuredArchiveFromArchive(Crc).GetSlot(),
+				const_cast<uint8*>(Prop.GetMemory()), nullptr);
+		}
+		Entry.Hash = Crc.GetCrc();
+		return Entry;
+	}
+
+	uint32 HashMaterials(const UStaticMeshComponent* Comp)
+	{
+		uint32 H = 0;
+		for (int32 i = 0; i < Comp->GetNumOverrideMaterials(); i++)
+		{
+			if (UMaterialInterface* M = Comp->GetMaterial(i))
+			{
+				H = HashCombine(H, GetTypeHash(FSoftObjectPath(M)));
+			}
+		}
+		return H;
+	}
+
+	// Variant index for the component's override set on the given entry; -1 = mesh defaults.
+	int32 TrackMaterialVariant(const UStaticMeshComponent* Comp, FPCGExMeshCollectionEntry& Entry, TMap<uint32, int32>& VariantHashToIndex)
+	{
+		const uint32 MatHash = HashMaterials(Comp);
+		if (MatHash == 0)
+		{
+			return -1;
+		}
+
+		if (const int32* Existing = VariantHashToIndex.Find(MatHash))
+		{
+			return *Existing;
+		}
+
+		const int32 VariantIdx = Entry.MaterialOverrideVariantsList.Num();
+		VariantHashToIndex.Add(MatHash, VariantIdx);
+
+		Entry.MaterialVariants = EPCGExMaterialVariantsMode::Multi;
+		FPCGExMaterialOverrideCollection& Variant = Entry.MaterialOverrideVariantsList.AddDefaulted_GetRef();
+		Variant.Weight = 1;
+		for (int32 SlotIdx = 0; SlotIdx < Comp->GetNumOverrideMaterials(); SlotIdx++)
+		{
+			FPCGExMaterialOverrideEntry& MatEntry = Variant.Overrides.AddDefaulted_GetRef();
+			MatEntry.SlotIndex = SlotIdx;
+			if (UMaterialInterface* M = Comp->GetMaterial(SlotIdx))
+			{
+				MatEntry.Material = TSoftObjectPtr<UMaterialInterface>(FSoftObjectPath(M));
+			}
+		}
+
+		return VariantIdx;
+	}
+
+	// Non-const ref because FSoftISMComponentDescriptor's copy ctor is explicit. OverrideMaterials are
+	// stripped transiently: they go on the entry as variants and must not influence identity.
+	template <typename TDescriptor>
+	uint32 FingerprintDescriptor(TDescriptor& Descriptor)
+	{
+		decltype(Descriptor.OverrideMaterials) SavedMaterials = MoveTemp(Descriptor.OverrideMaterials);
+		Descriptor.OverrideMaterials.Reset();
+
+		FArchiveCrc32 CrcArchive;
+		TDescriptor::StaticStruct()->SerializeBin(CrcArchive, &Descriptor);
+		const uint32 Crc = CrcArchive.GetCrc();
+
+		Descriptor.OverrideMaterials = MoveTemp(SavedMaterials);
+		return Crc;
+	}
+
+	// Identity hash deliberately omits Weight/Tags/Category/PropertyOverrides -- Weight accumulates from
+	// contributors, the rest are user-owned on the shared entry. Descriptors are not hashed (large
+	// structs); Equals resolves collisions.
+	uint32 ContentHash(const FPCGExMeshCollectionEntry& E)
+	{
+		uint32 H = GetTypeHash(E.StaticMesh.ToSoftObjectPath());
+		H = HashCombine(H, GetTypeHash(static_cast<uint8>(E.MaterialVariants)));
+		H = HashCombine(H, GetTypeHash(E.SlotIndex));
+		H = HashCombine(H, GetTypeHash(static_cast<uint8>(E.DescriptorSource)));
+
+		H = HashCombine(H, GetTypeHash(E.MaterialOverrideVariants.Num()));
+		for (const FPCGExMaterialOverrideSingleEntry& S : E.MaterialOverrideVariants)
+		{
+			H = HashCombine(H, GetTypeHash(S.Weight));
+			H = HashCombine(H, GetTypeHash(S.Material.ToSoftObjectPath()));
+		}
+
+		H = HashCombine(H, GetTypeHash(E.MaterialOverrideVariantsList.Num()));
+		for (const FPCGExMaterialOverrideCollection& V : E.MaterialOverrideVariantsList)
+		{
+			H = HashCombine(H, GetTypeHash(V.Weight));
+			H = HashCombine(H, GetTypeHash(V.Overrides.Num()));
+			for (const FPCGExMaterialOverrideEntry& O : V.Overrides)
+			{
+				H = HashCombine(H, GetTypeHash(O.SlotIndex));
+				H = HashCombine(H, GetTypeHash(O.Material.ToSoftObjectPath()));
+			}
+		}
+
+		H = HashCombine(H, E.PropertyComponentHash);
+		return H;
+	}
+
+	bool MaterialOverrideEquals(const FPCGExMaterialOverrideSingleEntry& A, const FPCGExMaterialOverrideSingleEntry& B)
+	{
+		return A.Weight == B.Weight && A.Material.ToSoftObjectPath() == B.Material.ToSoftObjectPath();
+	}
+
+	bool MaterialOverrideEquals(const FPCGExMaterialOverrideEntry& A, const FPCGExMaterialOverrideEntry& B)
+	{
+		return A.SlotIndex == B.SlotIndex && A.Material.ToSoftObjectPath() == B.Material.ToSoftObjectPath();
+	}
+
+	bool MaterialOverrideEquals(const FPCGExMaterialOverrideCollection& A, const FPCGExMaterialOverrideCollection& B)
+	{
+		if (A.Weight != B.Weight || A.Overrides.Num() != B.Overrides.Num())
+		{
+			return false;
+		}
+		for (int32 i = 0; i < A.Overrides.Num(); i++)
+		{
+			if (!MaterialOverrideEquals(A.Overrides[i], B.Overrides[i]))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool ContentEquals(const FPCGExMeshCollectionEntry& A, const FPCGExMeshCollectionEntry& B)
+	{
+		if (A.StaticMesh.ToSoftObjectPath() != B.StaticMesh.ToSoftObjectPath()
+			|| A.MaterialVariants != B.MaterialVariants
+			|| A.SlotIndex != B.SlotIndex
+			|| A.DescriptorSource != B.DescriptorSource
+			|| A.PropertyComponentHash != B.PropertyComponentHash)
+		{
+			return false;
+		}
+
+		if (A.MaterialOverrideVariants.Num() != B.MaterialOverrideVariants.Num())
+		{
+			return false;
+		}
+		for (int32 i = 0; i < A.MaterialOverrideVariants.Num(); i++)
+		{
+			if (!MaterialOverrideEquals(A.MaterialOverrideVariants[i], B.MaterialOverrideVariants[i]))
+			{
+				return false;
+			}
+		}
+
+		if (A.MaterialOverrideVariantsList.Num() != B.MaterialOverrideVariantsList.Num())
+		{
+			return false;
+		}
+		for (int32 i = 0; i < A.MaterialOverrideVariantsList.Num(); i++)
+		{
+			if (!MaterialOverrideEquals(A.MaterialOverrideVariantsList[i], B.MaterialOverrideVariantsList[i]))
+			{
+				return false;
+			}
+		}
+
+		if (!FSoftISMComponentDescriptor::StaticStruct()->CompareScriptStruct(&A.ISMDescriptor, &B.ISMDescriptor, 0))
+		{
+			return false;
+		}
+		if (!FPCGExStaticMeshComponentDescriptor::StaticStruct()->CompareScriptStruct(&A.SMDescriptor, &B.SMDescriptor, 0))
+		{
+			return false;
+		}
+		return true;
+	}
+
+	class FPolicy final : public IPCGExExportSlotPolicy
+	{
+	public:
+		virtual uint32 Hash(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return ContentHash(static_cast<const FPCGExMeshCollectionEntry&>(Entry));
+		}
+
+		virtual bool Equals(const FPCGExAssetCollectionEntry& A, const FPCGExAssetCollectionEntry& B) const override
+		{
+			return ContentEquals(static_cast<const FPCGExMeshCollectionEntry&>(A), static_cast<const FPCGExMeshCollectionEntry&>(B));
+		}
+
+		virtual FString SortKey(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return PCGExSharedCompact::MeshSortKey(static_cast<const FPCGExMeshCollectionEntry&>(Entry));
+		}
+
+		// Loose identity for EntryId preservation -- the binding survives variant/descriptor tweaks.
+		virtual FSoftObjectPath PrimaryPath(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return static_cast<const FPCGExMeshCollectionEntry&>(Entry).StaticMesh.ToSoftObjectPath();
+		}
+	};
+}
+
+FPCGExExportSlotDesc UPCGExMeshExportHandler::GetSlotDesc() const
+{
+	FPCGExExportSlotDesc Desc;
+	Desc.SlotId = PCGExLevelExport::Slots::Meshes;
+	Desc.PinName = PCGExCollections::Labels::MeshesPin;
+	Desc.CollectionClass = UPCGExMeshCollection::StaticClass();
+	Desc.EntryStruct = FPCGExMeshCollectionEntry::StaticStruct();
+	Desc.Scope = EPCGExExportSlotScope::Shared;
+	Desc.bSupportsSecondary = true;
+	return Desc;
+}
+
+TSharedPtr<const IPCGExExportSlotPolicy> UPCGExMeshExportHandler::MakePolicy() const
+{
+	return MakeShared<PCGExMeshExportHandler::FPolicy>();
+}
+
+// Mesh and Actor classifications are mutually exclusive -- Actor-classified actors with ISMCs are
+// intentionally NOT harvested here. Bounds are the mesh's intrinsic local AABB; the bounds evaluator is
+// not consulted because component variation belongs on per-entry descriptor data.
+void UPCGExMeshExportHandler::Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const
+{
+	using namespace PCGExMeshExportHandler;
+
+	if (Candidate.ClaimedSlot != PCGExLevelExport::Slots::Meshes)
+	{
+		return;
+	}
+
+	const UPCGExDefaultLevelDataExporter* Default = Cast<UPCGExDefaultLevelDataExporter>(Exporter);
+	const bool bCaptureMaterialOverrides = Default ? Default->bCaptureMaterialOverrides : true;
+
+	AActor* Actor = Candidate.Actor;
+	FScratch& Scratch = Writer.GetOrCreateScratch<FScratch>();
+
+	// Property-component identity is computed once per actor and folded into every mesh entry this actor
+	// contributes to, so actors authoring distinct property values land in distinct buckets.
+	const FActorPropertySchemaCache& Schema = GetOrComputeActorPropertySchema(Actor, Scratch.PropertySchemaCache);
+
+	TInlineComponentArray<UStaticMeshComponent*> SMCs;
+	Actor->GetComponents<UStaticMeshComponent>(SMCs);
+
+	for (UStaticMeshComponent* SMC : SMCs)
+	{
+		if (!SMC)
+		{
+			continue;
+		}
+
+		UStaticMesh* Mesh = SMC->GetStaticMesh();
+		if (!Mesh)
+		{
+			continue;
+		}
+
+		UInstancedStaticMeshComponent* ISMC = Cast<UInstancedStaticMeshComponent>(SMC);
+		const bool bIsISM = ISMC != nullptr;
+		const int32 InstanceCount = bIsISM ? ISMC->GetInstanceCount() : 1;
+		if (InstanceCount == 0)
+		{
+			continue;
+		}
+
+		FMeshEntryKey Key;
+		Key.MeshPath = FSoftObjectPath(Mesh);
+		Key.bIsISMSource = bIsISM;
+		Key.PropertyComponentHash = Schema.Hash;
+
+		FSoftISMComponentDescriptor TentativeISM;
+		FPCGExStaticMeshComponentDescriptor TentativeSM;
+
+		if (bIsISM)
+		{
+			TentativeISM.InitFrom(SMC, /*bInitBodyInstance=*/false);
+			Key.DescriptorFingerprint = FingerprintDescriptor(TentativeISM);
+		}
+		else
+		{
+			TentativeSM.InitFrom(SMC, /*bInitBodyInstance=*/false);
+			Key.DescriptorFingerprint = FingerprintDescriptor(TentativeSM);
+		}
+
+		// When capturing, variants are the sole material carrier: sec=-1 must mean mesh defaults, so the
+		// stored descriptor must not bake one contributor's overrides.
+		if (bCaptureMaterialOverrides)
+		{
+			TentativeISM.OverrideMaterials.Reset();
+			TentativeSM.OverrideMaterials.Reset();
+		}
+
+		const int32 LocalIdx = Writer.FindOrAddEntry(
+			GetTypeHash(Key),
+			[&Scratch, &Key](const int32 Index, const FPCGExAssetCollectionEntry&) { return Scratch.Keys[Index] == Key; },
+			[&](FPCGExAssetCollectionEntry& Base)
+			{
+				FPCGExMeshCollectionEntry& Entry = static_cast<FPCGExMeshCollectionEntry&>(Base);
+				Entry.StaticMesh = TSoftObjectPtr<UStaticMesh>(Key.MeshPath);
+				Entry.PropertyComponentHash = Key.PropertyComponentHash;
+				// First contribution stores the descriptor; later contributors share the fingerprint by
+				// construction, so the stored value is canonical.
+				if (bIsISM)
+				{
+					Entry.ISMDescriptor = MoveTemp(TentativeISM);
+				}
+				else
+				{
+					Entry.SMDescriptor = MoveTemp(TentativeSM);
+				}
+
+				// All contributors to this bucket share the property hash, so the first actor's resolved
+				// values are canonical. Outer identity seeded so the entry ships in SyncToSchema shape.
+				if (!Schema.Resolved.IsEmpty())
+				{
+					Entry.PropertyOverrides.Overrides.Reset(Schema.Resolved.Num());
+					for (const FInstancedStruct& Prop : Schema.Resolved)
+					{
+						FPCGExPropertyOverrideEntry& Slot = Entry.PropertyOverrides.Overrides.AddDefaulted_GetRef();
+						Slot.Value = Prop;
+						Slot.bEnabled = true;
+#if WITH_EDITORONLY_DATA
+						Slot.SeedOuterIdentityFromInner();
+#endif
+					}
+				}
+
+				Scratch.Keys.Add(Key);
+				Scratch.VariantHashToIndex.AddDefaulted();
+			},
+			InstanceCount);
+
+		FPCGExMeshCollectionEntry& Entry = Writer.GetEntry<FPCGExMeshCollectionEntry>(LocalIdx);
+		const int16 VariantIdx = bCaptureMaterialOverrides
+			? static_cast<int16>(TrackMaterialVariant(SMC, Entry, Scratch.VariantHashToIndex[LocalIdx]))
+			: static_cast<int16>(-1);
+
+		const FBox MeshBounds = Mesh->GetBoundingBox();
+
+		if (bIsISM)
+		{
+			Writer.Items.Reserve(Writer.Items.Num() + InstanceCount);
+			for (int32 Idx = 0; Idx < InstanceCount; Idx++)
+			{
+				FTransform InstanceWorld;
+				ISMC->GetInstanceTransform(Idx, InstanceWorld, /*bWorldSpace=*/true);
+				Writer.AddItem(Source.ToFrame(InstanceWorld), MeshBounds.Min, MeshBounds.Max, Actor, LocalIdx, VariantIdx);
+			}
+		}
+		else
+		{
+			Writer.AddItem(Source.ToFrame(SMC->GetComponentTransform()), MeshBounds.Min, MeshBounds.Max, Actor, LocalIdx, VariantIdx);
+		}
+	}
+}
+
+// "Common-ancestor" inherited-defaults view of the contributing actors: per property, the value all
+// unique BP classes agree on at the CDO level, else the asset's authored default. Seeds the shared mesh
+// collection's CollectionProperties without falling back to whichever per-instance override came first.
+void UPCGExMeshExportHandler::FinalizeSlot(FPCGExExportSlotWriter& Writer, UObject* Outer, const UPCGExLevelDataExporter* Exporter) const
+{
+	using namespace PCGExMeshExportHandler;
+
+	FScratch& Scratch = Writer.GetOrCreateScratch<FScratch>();
+
+	TMap<UClass*, TArray<FInstancedStruct>> InheritedByClass;
+	TMap<UClass*, TArray<FInstancedStruct>> AssetDefaultsByClass;
+	for (const TPair<AActor*, FActorPropertySchemaCache>& Pair : Scratch.PropertySchemaCache)
+	{
+		AActor* Actor = Pair.Key;
+		if (!Actor)
+		{
+			continue;
+		}
+		UClass* Class = Actor->GetClass();
+		if (InheritedByClass.Contains(Class))
+		{
+			continue;
+		}
+		UPCGExPropertyCollectionComponent* Comp = UPCGExPropertyCollectionComponent::FindOnActor(Actor);
+		if (!Comp)
+		{
+			continue;
+		}
+		InheritedByClass.Add(Class, Comp->BuildInheritedSchema());
+		AssetDefaultsByClass.Add(Class, Comp->BuildAssetDefaultSchema());
+	}
+
+	TArray<TConstArrayView<FInstancedStruct>> InheritedViews;
+	InheritedViews.Reserve(InheritedByClass.Num());
+	for (const TPair<UClass*, TArray<FInstancedStruct>>& Pair : InheritedByClass)
+	{
+		InheritedViews.Emplace(Pair.Value);
+	}
+	TArray<TConstArrayView<FInstancedStruct>> AssetDefaultViews;
+	AssetDefaultViews.Reserve(AssetDefaultsByClass.Num());
+	for (const TPair<UClass*, TArray<FInstancedStruct>>& Pair : AssetDefaultsByClass)
+	{
+		AssetDefaultViews.Emplace(Pair.Value);
+	}
+	Writer.InheritedDefaults = PCGExProperties::AggregateAgreedValuesByName(InheritedViews, AssetDefaultViews);
+}
+
+void UPCGExMeshExportHandler::WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+{
+	FPCGMetadataAttribute<FSoftObjectPath>* MeshAttr = Meta->CreateAttribute<FSoftObjectPath>(TEXT("Mesh"), FSoftObjectPath(), false, true);
+	if (!MeshAttr)
+	{
+		return;
+	}
+	for (int32 i = 0; i < Writer.Items.Num(); i++)
+	{
+		const int32 LocalIdx = Writer.Items[i].LocalEntryIndex;
+		if (LocalIdx >= 0)
+		{
+			MeshAttr->SetValue(MetaEntries[i], Writer.GetEntry<FPCGExMeshCollectionEntry>(LocalIdx).StaticMesh.ToSoftObjectPath());
+		}
+	}
+}
+
+#pragma endregion
+
+#pragma region Actor
+
+namespace PCGExActorExportHandler
+{
+	struct FActorInstanceKey
+	{
+		FSoftClassPath ClassPath;
+		uint32 DeltaHash = 0;
+
+		bool operator==(const FActorInstanceKey& Other) const
+		{
+			return ClassPath == Other.ClassPath && DeltaHash == Other.DeltaHash;
+		}
+
+		friend uint32 GetTypeHash(const FActorInstanceKey& Key)
+		{
+			return HashCombine(GetTypeHash(Key.ClassPath), Key.DeltaHash);
+		}
+	};
+
+	struct FScratch final : FPCGExExportScratch
+	{
+		// Parallel to the writer's entries. The representative is the first actor of the bucket -- the one
+		// whose authored state the stored delta reflects; every member shares the delta hash, so any is a
+		// valid donor for the property-component scan.
+		TArray<FActorInstanceKey> Keys;
+		TArray<AActor*> Representatives;
+	};
+
+	uint32 EntryHash(const FPCGExActorCollectionEntry& E)
+	{
+		return HashCombine(GetTypeHash(FSoftClassPath(E.Actor.ToString())), PCGExActorDelta::HashDelta(E.SerializedPropertyDelta));
+	}
+
+	class FPolicy final : public IPCGExExportSlotPolicy
+	{
+	public:
+		virtual uint32 Hash(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return EntryHash(static_cast<const FPCGExActorCollectionEntry&>(Entry));
+		}
+
+		virtual bool Equals(const FPCGExAssetCollectionEntry& A, const FPCGExAssetCollectionEntry& B) const override
+		{
+			const FPCGExActorCollectionEntry& EA = static_cast<const FPCGExActorCollectionEntry&>(A);
+			const FPCGExActorCollectionEntry& EB = static_cast<const FPCGExActorCollectionEntry&>(B);
+			return EA.Actor.ToSoftObjectPath() == EB.Actor.ToSoftObjectPath() && EA.SerializedPropertyDelta == EB.SerializedPropertyDelta;
+		}
+
+		virtual FString SortKey(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			const FPCGExActorCollectionEntry& E = static_cast<const FPCGExActorCollectionEntry&>(Entry);
+			return FString::Printf(TEXT("%s|%08X"), *E.Actor.ToString(), PCGExActorDelta::HashDelta(E.SerializedPropertyDelta));
+		}
+
+		// Class alone: the binding survives a delta change.
+		virtual FSoftObjectPath PrimaryPath(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return static_cast<const FPCGExActorCollectionEntry&>(Entry).Actor.ToSoftObjectPath();
+		}
+	};
+}
+
+FPCGExExportSlotDesc UPCGExActorExportHandler::GetSlotDesc() const
+{
+	FPCGExExportSlotDesc Desc;
+	Desc.SlotId = PCGExLevelExport::Slots::Actors;
+	Desc.PinName = PCGExCollections::Labels::ActorsPin;
+	Desc.CollectionClass = UPCGExActorCollection::StaticClass();
+	Desc.EntryStruct = FPCGExActorCollectionEntry::StaticStruct();
+	Desc.Scope = EPCGExExportSlotScope::PerEntry;
+	return Desc;
+}
+
+TSharedPtr<const IPCGExExportSlotPolicy> UPCGExActorExportHandler::MakePolicy() const
+{
+	return MakeShared<PCGExActorExportHandler::FPolicy>();
+}
+
+void UPCGExActorExportHandler::Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const
+{
+	using namespace PCGExActorExportHandler;
+
+	if (Candidate.ClaimedSlot != PCGExLevelExport::Slots::Actors)
+	{
+		return;
+	}
+
+	const UPCGExDefaultLevelDataExporter* Default = Cast<UPCGExDefaultLevelDataExporter>(Exporter);
+	const bool bCaptureDeltas = Default ? (Default->bCapturePropertyDeltas && Default->bGenerateCollections) : false;
+	const EPCGExValueTagMode ValueTagMode = Default ? Default->ValueTagMode : EPCGExValueTagMode::NoParsing;
+	const UPCGExBoundsEvaluator* BoundsEvaluator = Default ? Default->BoundsEvaluator.Get() : nullptr;
+
+	AActor* Actor = Candidate.Actor;
+	FScratch& Scratch = Writer.GetOrCreateScratch<FScratch>();
+
+	TArray<uint8> DeltaBytes;
+	TArray<FSoftObjectPath> DeltaCollaterals;
+	uint32 DeltaHash = 0;
+	if (bCaptureDeltas)
+	{
+		DeltaBytes = PCGExActorDelta::SerializeActorDelta(Actor, &DeltaCollaterals);
+		DeltaHash = PCGExActorDelta::HashDelta(DeltaBytes);
+	}
+
+	FActorInstanceKey Key;
+	Key.ClassPath = FSoftClassPath(Actor->GetClass());
+	Key.DeltaHash = DeltaHash;
+
+	// Raw Actor->Tags feed the property delta; the entry's Tags are the parse-mode effective set,
+	// intersected across the bucket.
+	const TSet<FName> EffectiveTags = PCGExLevelExportShared::BuildEffectiveTags(Actor, ValueTagMode);
+
+	bool bAdded = false;
+	const int32 LocalIdx = Writer.FindOrAddEntry(
+		GetTypeHash(Key),
+		[&Scratch, &Key](const int32 Index, const FPCGExAssetCollectionEntry&) { return Scratch.Keys[Index] == Key; },
+		[&](FPCGExAssetCollectionEntry& Base)
+		{
+			FPCGExActorCollectionEntry& Entry = static_cast<FPCGExActorCollectionEntry&>(Base);
+			Entry.Actor = TSoftClassPtr<AActor>(Key.ClassPath);
+			Entry.Tags = EffectiveTags;
+			if (!DeltaBytes.IsEmpty())
+			{
+				Entry.SerializedPropertyDelta = MoveTemp(DeltaBytes);
+				Entry.DeltaCollateralPaths = MoveTemp(DeltaCollaterals);
+			}
+			Scratch.Keys.Add(Key);
+			Scratch.Representatives.Add(Actor);
+			bAdded = true;
+		});
+
+	if (!bAdded)
+	{
+		FPCGExActorCollectionEntry& Entry = Writer.GetEntry<FPCGExActorCollectionEntry>(LocalIdx);
+		Entry.Tags = Entry.Tags.Intersect(EffectiveTags);
+	}
+
+	FTransform Transform;
+	FVector BoundsMin, BoundsMax;
+	PCGExLevelExportShared::EvaluateActorItem(Actor, Source, BoundsEvaluator, Transform, BoundsMin, BoundsMax);
+	Writer.AddItem(Transform, BoundsMin, BoundsMax, Actor, LocalIdx);
+}
+
+// Per-actor tag names as a joined string. Only meaningful in NoParsing and ParseAndKeep modes; under
+// Parse every tag is already a typed attribute.
+void UPCGExActorExportHandler::WriteItemAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+{
+	const UPCGExDefaultLevelDataExporter* Default = Cast<UPCGExDefaultLevelDataExporter>(Exporter);
+	if (!Default || !Default->bWriteInstanceTags || Default->InstanceTagsAttributeName == NAME_None || Default->ValueTagMode == EPCGExValueTagMode::Parse)
+	{
+		return;
+	}
+
+	FPCGMetadataAttribute<FString>* InstanceTagsAttr = Meta->CreateAttribute<FString>(Default->InstanceTagsAttributeName, FString(), false, true);
+	if (!InstanceTagsAttr)
+	{
+		return;
+	}
+
+	for (int32 i = 0; i < Writer.Items.Num(); i++)
+	{
+		const FString TagsStr = PCGExLevelExportShared::BuildInstanceTagString(Writer.Items[i].SourceActor, Default->ValueTagMode);
+		if (!TagsStr.IsEmpty())
+		{
+			InstanceTagsAttr->SetValue(MetaEntries[i], TagsStr);
+		}
+	}
+}
+
+void UPCGExActorExportHandler::WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+{
+	FPCGMetadataAttribute<FSoftClassPath>* ActorClassAttr = Meta->CreateAttribute<FSoftClassPath>(TEXT("ActorClass"), FSoftClassPath(), false, true);
+	if (!ActorClassAttr)
+	{
+		return;
+	}
+	for (int32 i = 0; i < Writer.Items.Num(); i++)
+	{
+		ActorClassAttr->SetValue(MetaEntries[i], FSoftClassPath(Writer.Items[i].SourceActor->GetClass()));
+	}
+}
+
+// Scan UPCGExPropertyCollectionComponent on each representative actor and merge into the embedded
+// collection's schema + per-entry overrides. Runs BEFORE the staging rebuild so it observes the final
+// schema. The exporter's policy is mirrored onto the collection so a manual rebuild uses the same one.
+void UPCGExActorExportHandler::FinalizeEmbeddedCollection(UPCGExAssetCollection* Collection, FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+{
+	using namespace PCGExActorExportHandler;
+
+	UPCGExActorCollection* ActorCollection = Cast<UPCGExActorCollection>(Collection);
+	if (!ActorCollection)
+	{
+		return;
+	}
+
+	const UPCGExDefaultLevelDataExporter* Default = Cast<UPCGExDefaultLevelDataExporter>(Exporter);
+	const EPCGExSchemaMergePolicy Policy = Default ? Default->SchemaMergePolicy : EPCGExSchemaMergePolicy::StrictTypeMatch;
+
+	FScratch& Scratch = Writer.GetOrCreateScratch<FScratch>();
+	ActorCollection->SchemaMergePolicy = Policy;
+	ActorCollection->RebuildPropertiesFromActorComponents(Policy, Scratch.Representatives);
+}
+
+#pragma endregion
+
+#pragma region LevelInstance
+
+namespace PCGExLevelInstanceExportHandler
+{
+	class FPolicy final : public IPCGExExportSlotPolicy
+	{
+	public:
+		virtual uint32 Hash(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return GetTypeHash(static_cast<const FPCGExLevelCollectionEntry&>(Entry).Level.ToSoftObjectPath());
+		}
+
+		virtual bool Equals(const FPCGExAssetCollectionEntry& A, const FPCGExAssetCollectionEntry& B) const override
+		{
+			return static_cast<const FPCGExLevelCollectionEntry&>(A).Level.ToSoftObjectPath() == static_cast<const FPCGExLevelCollectionEntry&>(B).Level.ToSoftObjectPath();
+		}
+
+		virtual FString SortKey(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return PCGExSharedCompact::LevelSortKey(static_cast<const FPCGExLevelCollectionEntry&>(Entry));
+		}
+
+		virtual FSoftObjectPath PrimaryPath(const FPCGExAssetCollectionEntry& Entry) const override
+		{
+			return static_cast<const FPCGExLevelCollectionEntry&>(Entry).Level.ToSoftObjectPath();
+		}
+	};
+}
+
+FPCGExExportSlotDesc UPCGExLevelInstanceExportHandler::GetSlotDesc() const
+{
+	FPCGExExportSlotDesc Desc;
+	Desc.SlotId = PCGExLevelExport::Slots::Levels;
+	Desc.PinName = PCGExCollections::Labels::LevelsPin;
+	Desc.CollectionClass = UPCGExLevelCollection::StaticClass();
+	Desc.EntryStruct = FPCGExLevelCollectionEntry::StaticStruct();
+	Desc.Scope = EPCGExExportSlotScope::Shared;
+	return Desc;
+}
+
+TSharedPtr<const IPCGExExportSlotPolicy> UPCGExLevelInstanceExportHandler::MakePolicy() const
+{
+	return MakeShared<PCGExLevelInstanceExportHandler::FPolicy>();
+}
+
+void UPCGExLevelInstanceExportHandler::Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const
+{
+	if (Candidate.ClaimedSlot != PCGExLevelExport::Slots::Levels)
+	{
+		return;
+	}
+
+	const ALevelInstance* LI = Cast<ALevelInstance>(Candidate.Actor);
+	if (!LI)
+	{
+		return;
+	}
+	const FSoftObjectPath LevelPath = LI->GetWorldAsset().ToSoftObjectPath();
+	if (LevelPath.IsNull())
+	{
+		return;
+	}
+
+	const UPCGExDefaultLevelDataExporter* Default = Cast<UPCGExDefaultLevelDataExporter>(Exporter);
+	const UPCGExBoundsEvaluator* BoundsEvaluator = Default ? Default->BoundsEvaluator.Get() : nullptr;
+
+	const int32 LocalIdx = Writer.FindOrAddEntry(
+		GetTypeHash(LevelPath),
+		[&LevelPath](const int32, const FPCGExAssetCollectionEntry& Entry) { return static_cast<const FPCGExLevelCollectionEntry&>(Entry).Level.ToSoftObjectPath() == LevelPath; },
+		[&LevelPath](FPCGExAssetCollectionEntry& Entry) { static_cast<FPCGExLevelCollectionEntry&>(Entry).Level = TSoftObjectPtr<UWorld>(LevelPath); });
+
+	FTransform Transform;
+	FVector BoundsMin, BoundsMax;
+	PCGExLevelExportShared::EvaluateActorItem(Candidate.Actor, Source, BoundsEvaluator, Transform, BoundsMin, BoundsMax);
+	Writer.AddItem(Transform, BoundsMin, BoundsMax, Candidate.Actor, LocalIdx);
+}
+
+void UPCGExLevelInstanceExportHandler::WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+{
+	FPCGMetadataAttribute<FSoftObjectPath>* LevelAssetAttr = Meta->CreateAttribute<FSoftObjectPath>(TEXT("LevelAsset"), FSoftObjectPath(), false, true);
+	if (!LevelAssetAttr)
+	{
+		return;
+	}
+	for (int32 i = 0; i < Writer.Items.Num(); i++)
+	{
+		const int32 LocalIdx = Writer.Items[i].LocalEntryIndex;
+		if (LocalIdx >= 0)
+		{
+			LevelAssetAttr->SetValue(MetaEntries[i], Writer.GetEntry<FPCGExLevelCollectionEntry>(LocalIdx).Level.ToSoftObjectPath());
+		}
+	}
+}
+
+#pragma endregion
+
+#pragma region Registration
+
+namespace PCGExLevelExport
+{
+	void RegisterBuiltinHandlers()
+	{
+		FHandlerRegistry& Registry = FHandlerRegistry::Get();
+		Registry.Register(UPCGExMeshExportHandler::StaticClass());
+		Registry.Register(UPCGExActorExportHandler::StaticClass());
+		Registry.Register(UPCGExLevelInstanceExportHandler::StaticClass());
+	}
+
+	void UnregisterBuiltinHandlers()
+	{
+		FHandlerRegistry& Registry = FHandlerRegistry::Get();
+		Registry.Unregister(Slots::Meshes);
+		Registry.Unregister(Slots::Actors);
+		Registry.Unregister(Slots::Levels);
+	}
+
+	bool IsBuiltinHandlerClass(const UClass* HandlerClass)
+	{
+		return HandlerClass
+			&& (HandlerClass->IsChildOf<UPCGExMeshExportHandler>()
+				|| HandlerClass->IsChildOf<UPCGExActorExportHandler>()
+				|| HandlerClass->IsChildOf<UPCGExLevelInstanceExportHandler>());
+	}
+}
+
+#pragma endregion
+
+#endif // WITH_EDITOR

--- a/Source/PCGExCollections/Private/Helpers/PCGExLevelExportHandler.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExLevelExportHandler.cpp
@@ -1,0 +1,184 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "Helpers/PCGExLevelExportHandler.h"
+
+#include "PCGExLog.h"
+#include "Core/PCGExAssetCollection.h"
+
+#if WITH_EDITOR
+
+#pragma region FPCGExExportSlotWriter
+
+FPCGExExportSlotWriter::FPCGExExportSlotWriter(const FPCGExExportSlotDesc& InDesc)
+	: Desc(InDesc)
+{
+}
+
+int32 FPCGExExportSlotWriter::FindOrAddEntry(
+	const uint32 IdentityHash,
+	TFunctionRef<bool(int32 LocalIndex, const FPCGExAssetCollectionEntry&)> Equals,
+	TFunctionRef<void(FPCGExAssetCollectionEntry&)> Init,
+	const int32 WeightIncrement)
+{
+	TArray<int32>& Bucket = Buckets.FindOrAdd(IdentityHash);
+	for (const int32 LocalIndex : Bucket)
+	{
+		if (Equals(LocalIndex, GetEntry(LocalIndex)))
+		{
+			GetEntry(LocalIndex).Weight += WeightIncrement;
+			return LocalIndex;
+		}
+	}
+
+	const int32 LocalIndex = Entries.Num();
+	FInstancedStruct& Added = Entries.AddDefaulted_GetRef();
+	Added.InitializeAs(Desc.EntryStruct);
+
+	FPCGExAssetCollectionEntry& Entry = *Added.GetMutablePtr<FPCGExAssetCollectionEntry>();
+	Init(Entry);
+	// Weight is the pick count, never the struct default.
+	Entry.Weight = WeightIncrement;
+
+	Bucket.Add(LocalIndex);
+	return LocalIndex;
+}
+
+FPCGExAssetCollectionEntry& FPCGExExportSlotWriter::GetEntry(const int32 LocalIndex)
+{
+	return *Entries[LocalIndex].GetMutablePtr<FPCGExAssetCollectionEntry>();
+}
+
+const FPCGExAssetCollectionEntry& FPCGExExportSlotWriter::GetEntry(const int32 LocalIndex) const
+{
+	return *Entries[LocalIndex].GetPtr<FPCGExAssetCollectionEntry>();
+}
+
+FPCGExExportItem& FPCGExExportSlotWriter::AddItem(const FTransform& InTransform, const FVector& InBoundsMin, const FVector& InBoundsMax, AActor* InSourceActor, const int32 InLocalEntryIndex, const int16 InSecondaryIndex)
+{
+	FPCGExExportItem& Item = Items.AddDefaulted_GetRef();
+	Item.Transform = InTransform;
+	Item.BoundsMin = InBoundsMin;
+	Item.BoundsMax = InBoundsMax;
+	Item.SourceActor = InSourceActor;
+	Item.LocalEntryIndex = InLocalEntryIndex;
+	Item.SecondaryIndex = InSecondaryIndex;
+	return Item;
+}
+
+#pragma endregion
+
+#pragma region FHandlerRegistry
+
+namespace PCGExLevelExport
+{
+	FHandlerRegistry& FHandlerRegistry::Get()
+	{
+		static FHandlerRegistry Instance;
+		return Instance;
+	}
+
+	bool FHandlerRegistry::Register(const TSubclassOf<UPCGExLevelExportHandler> HandlerClass)
+	{
+		if (!HandlerClass || HandlerClass->HasAnyClassFlags(CLASS_Abstract))
+		{
+			UE_LOG(LogPCGEx, Error, TEXT("Level export handler registration refused: null or abstract class."));
+			return false;
+		}
+
+		const UPCGExLevelExportHandler* CDO = HandlerClass->GetDefaultObject<UPCGExLevelExportHandler>();
+		FHandlerRegistration Registration;
+		Registration.Desc = CDO->GetSlotDesc();
+		Registration.Policy = CDO->MakePolicy();
+		Registration.HandlerClass = HandlerClass;
+		Registration.Priority = CDO->GetPriority();
+
+		if (!Registration.Desc.IsValid() || !Registration.Policy)
+		{
+			UE_LOG(LogPCGEx, Error, TEXT("Level export handler '%s' refused: incomplete slot descriptor or null policy."), *HandlerClass->GetName());
+			return false;
+		}
+
+		if (!Registration.Desc.EntryStruct->IsChildOf(FPCGExAssetCollectionEntry::StaticStruct()))
+		{
+			UE_LOG(LogPCGEx, Error, TEXT("Level export handler '%s' refused: entry struct '%s' is not an asset collection entry."), *HandlerClass->GetName(), *Registration.Desc.EntryStruct->GetName());
+			return false;
+		}
+
+		if (!Registration.Desc.CollectionClass->IsChildOf<UPCGExAssetCollection>() || Registration.Desc.CollectionClass->HasAnyClassFlags(CLASS_Abstract))
+		{
+			UE_LOG(LogPCGEx, Error, TEXT("Level export handler '%s' refused: '%s' is not a concrete asset collection class."), *HandlerClass->GetName(), *Registration.Desc.CollectionClass->GetName());
+			return false;
+		}
+
+		FWriteScopeLock WriteLock(Lock);
+		if (const FHandlerRegistration* Existing = Registrations.Find(Registration.Desc.SlotId))
+		{
+			UE_LOG(LogPCGEx, Error, TEXT("Level export slot '%s' is already registered by '%s'; '%s' refused."),
+			       *Registration.Desc.SlotId.ToString(), *GetNameSafe(Existing->HandlerClass), *HandlerClass->GetName());
+			return false;
+		}
+		Registrations.Add(Registration.Desc.SlotId, MoveTemp(Registration));
+		return true;
+	}
+
+	void FHandlerRegistry::Unregister(const FName SlotId)
+	{
+		FWriteScopeLock WriteLock(Lock);
+		Registrations.Remove(SlotId);
+	}
+
+	bool FHandlerRegistry::FindSlot(const FName SlotId, FPCGExExportSlotDesc& OutDesc) const
+	{
+		FReadScopeLock ReadLock(Lock);
+		if (const FHandlerRegistration* Found = Registrations.Find(SlotId))
+		{
+			OutDesc = Found->Desc;
+			return true;
+		}
+		return false;
+	}
+
+	TSharedPtr<const IPCGExExportSlotPolicy> FHandlerRegistry::GetPolicy(const FName SlotId) const
+	{
+		FReadScopeLock ReadLock(Lock);
+		const FHandlerRegistration* Found = Registrations.Find(SlotId);
+		return Found ? Found->Policy : nullptr;
+	}
+
+	void FHandlerRegistry::GetRegistrations(TArray<FHandlerRegistration>& OutRegistrations) const
+	{
+		{
+			FReadScopeLock ReadLock(Lock);
+			OutRegistrations.Reserve(OutRegistrations.Num() + Registrations.Num());
+			for (const TPair<FName, FHandlerRegistration>& Pair : Registrations)
+			{
+				OutRegistrations.Add(Pair.Value);
+			}
+		}
+		// Priority, then slot id: a stable order across sessions regardless of registration order.
+		OutRegistrations.Sort([](const FHandlerRegistration& A, const FHandlerRegistration& B)
+		{
+			if (A.Priority != B.Priority)
+			{
+				return A.Priority < B.Priority;
+			}
+			return A.Desc.SlotId.LexicalLess(B.Desc.SlotId);
+		});
+	}
+
+	void FHandlerRegistry::GetSlots(TArray<FPCGExExportSlotDesc>& OutSlots) const
+	{
+		TArray<FHandlerRegistration> Copies;
+		GetRegistrations(Copies);
+		OutSlots.Reserve(OutSlots.Num() + Copies.Num());
+		for (const FHandlerRegistration& Registration : Copies)
+		{
+			OutSlots.Add(Registration.Desc);
+		}
+	}
+}
+
+#pragma endregion
+
+#endif // WITH_EDITOR

--- a/Source/PCGExCollections/Private/Helpers/PCGExLevelExportShared.h
+++ b/Source/PCGExCollections/Private/Helpers/PCGExLevelExportShared.h
@@ -1,0 +1,258 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if WITH_EDITOR
+
+#include "PCGExLog.h"
+#include "Data/PCGExDataValue.h"
+#include "Data/PCGPointArrayData.h"
+#include "GameFramework/Actor.h"
+#include "Helpers/PCGExDefaultLevelDataExporter.h"
+#include "Helpers/PCGExMetaHelpersMacros.h"
+#include "Helpers/PCGExPointArrayDataHelpers.h"
+#include "Metadata/PCGMetadata.h"
+
+/**
+ * Point-data and actor-tag helpers shared by the default exporter and the built-in export handlers.
+ * Module-private; inline in a named namespace so Unity builds never see two definitions.
+ */
+namespace PCGExLevelExportShared
+{
+	/** Point data with transform + bounds allocated, ranges returned for filling. */
+	inline UPCGBasePointData* CreatePointData(
+		UObject* Outer, const int32 NumPoints,
+		TPCGValueRange<FTransform>& OutTransforms,
+		TPCGValueRange<FVector>& OutBoundsMin,
+		TPCGValueRange<FVector>& OutBoundsMax)
+	{
+		UPCGBasePointData* PointData = NewObject<UPCGPointArrayData>(Outer);
+		PCGExPointArrayDataHelpers::SetNumPointsAllocated(
+			PointData, NumPoints,
+			EPCGPointNativeProperties::Transform | EPCGPointNativeProperties::BoundsMin | EPCGPointNativeProperties::BoundsMax);
+
+		OutTransforms = PointData->GetTransformValueRange();
+		OutBoundsMin = PointData->GetBoundsMinValueRange();
+		OutBoundsMax = PointData->GetBoundsMaxValueRange();
+
+		return PointData;
+	}
+
+	inline void InitMetadata(UPCGBasePointData* PointData, const int32 NumPoints)
+	{
+		UPCGMetadata* Meta = PointData->MutableMetadata();
+		TPCGValueRange<int64> MetaEntries = PointData->GetMetadataEntryValueRange();
+
+		TArray<TTuple<int64, int64>> DelayedEntries;
+		DelayedEntries.SetNum(NumPoints);
+
+		for (int32 i = 0; i < NumPoints; i++)
+		{
+			MetaEntries[i] = Meta->AddEntryPlaceholder();
+			DelayedEntries[i] = MakeTuple(MetaEntries[i], static_cast<int64>(-1));
+		}
+
+		Meta->AddDelayedEntries(DelayedEntries);
+	}
+
+	inline void WorldBoundsToLocal(const FBox& WorldBounds, const FTransform& ActorTransform, FVector& OutBoundsMin, FVector& OutBoundsMax)
+	{
+		if (WorldBounds.IsValid)
+		{
+			const FTransform InvTransform = ActorTransform.Inverse();
+			const FVector LocalMin = InvTransform.TransformPosition(WorldBounds.Min);
+			const FVector LocalMax = InvTransform.TransformPosition(WorldBounds.Max);
+
+			// Re-min/max after transform (rotation can swap axes)
+			OutBoundsMin = LocalMin.ComponentMin(LocalMax);
+			OutBoundsMax = LocalMin.ComponentMax(LocalMax);
+		}
+		else
+		{
+			OutBoundsMin = FVector::ZeroVector;
+			OutBoundsMax = FVector::ZeroVector;
+		}
+	}
+
+	/** Bounds stay relative to the actor's own transform (frame-invariant); only the written transform moves into the source frame. */
+	inline void EvaluateActorItem(AActor* Actor, const FPCGExLevelExportSource& Source, const UPCGExBoundsEvaluator* Evaluator, FTransform& OutTransform, FVector& OutBoundsMin, FVector& OutBoundsMax)
+	{
+		const FTransform ActorTransform = Actor->GetActorTransform();
+		OutTransform = Source.ToFrame(ActorTransform);
+
+		const FBox WorldBounds = Evaluator ? Evaluator->EvaluateActorBounds(Actor, nullptr, -1) : FBox(ForceInit);
+		WorldBoundsToLocal(WorldBounds, ActorTransform, OutBoundsMin, OutBoundsMax);
+	}
+
+	/** Attribute name -> PCG metadata type. First registration wins; conflicts are warned and discarded. */
+	struct FValueTagRegistry
+	{
+		TMap<FName, EPCGMetadataTypes> TypeMap;
+
+		bool Register(const FName& Name, const EPCGMetadataTypes NewType, const FString& SourceActorName)
+		{
+			if (const EPCGMetadataTypes* Existing = TypeMap.Find(Name))
+			{
+				if (*Existing != NewType)
+				{
+					UE_LOG(LogPCGEx, Warning,
+					       TEXT("Value tag type conflict: '%s' on actor '%s'. Attribute was already registered with a different type; this actor's value will be discarded."),
+					       *Name.ToString(), *SourceActorName);
+					return false;
+				}
+				return true;
+			}
+			TypeMap.Add(Name, NewType);
+			return true;
+		}
+	};
+
+	/** PlainTags become bool=true attributes; ValueTags (Name:Value) become typed attributes. */
+	struct FParsedActorTags
+	{
+		TArray<FName> PlainTags;
+		TArray<TPair<FName, TSharedPtr<PCGExData::IDataValue>>> ValueTags;
+	};
+
+	/** Null registry parses silently (no type bookkeeping) -- for tag SETS, never for attribute writes. */
+	inline FParsedActorTags ParseActorTags(const AActor* Actor, FValueTagRegistry* Registry)
+	{
+		FParsedActorTags Result;
+		const FString ActorName = Actor->GetActorNameOrLabel();
+
+		for (const FName& Tag : Actor->Tags)
+		{
+			FString Key;
+			const TSharedPtr<PCGExData::IDataValue> DataValue = PCGExData::TryGetValueFromTag(Tag.ToString(), Key);
+
+			if (DataValue.IsValid())
+			{
+				const FName AttrName(Key);
+				if (!Registry || Registry->Register(AttrName, DataValue->GetTypeId(), ActorName))
+				{
+					Result.ValueTags.Add(TPair<FName, TSharedPtr<PCGExData::IDataValue>>(AttrName, DataValue));
+				}
+			}
+			else if (!Registry || Registry->Register(Tag, EPCGMetadataTypes::Boolean, ActorName))
+			{
+				Result.PlainTags.Add(Tag);
+			}
+		}
+		return Result;
+	}
+
+	inline TMap<FName, FPCGMetadataAttributeBase*> CreateValueTagAttributes(UPCGMetadata* Meta, const FValueTagRegistry& Registry)
+	{
+		TMap<FName, FPCGMetadataAttributeBase*> AttrMap;
+		AttrMap.Reserve(Registry.TypeMap.Num());
+
+		for (const TPair<FName, EPCGMetadataTypes>& Elem : Registry.TypeMap)
+		{
+			const FName& Name = Elem.Key;
+			FPCGMetadataAttributeBase* Attr = nullptr;
+#define PCGEX_CREATE_VALUE_TAG_ATTR(_TYPE, _NAME) Attr = Meta->CreateAttribute<_TYPE>(Name, _TYPE{}, false, true);
+			PCGEX_EXECUTEWITHRIGHTTYPE(Elem.Value, PCGEX_CREATE_VALUE_TAG_ATTR)
+#undef PCGEX_CREATE_VALUE_TAG_ATTR
+			if (Attr)
+			{
+				AttrMap.Add(Name, Attr);
+			}
+		}
+		return AttrMap;
+	}
+
+	inline void SetValueTagAttributes(const TMap<FName, FPCGMetadataAttributeBase*>& AttrMap, const int64 Entry, const FParsedActorTags& Parsed)
+	{
+		for (const FName& Tag : Parsed.PlainTags)
+		{
+			if (FPCGMetadataAttributeBase* const* BasePtr = AttrMap.Find(Tag))
+			{
+				static_cast<FPCGMetadataAttribute<bool>*>(*BasePtr)->SetValue(Entry, true);
+			}
+		}
+
+		for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
+		{
+			FPCGMetadataAttributeBase* const* BasePtr = AttrMap.Find(VT.Key);
+			if (!BasePtr)
+			{
+				continue;
+			}
+
+			FPCGMetadataAttributeBase* Base = *BasePtr;
+			const TSharedPtr<PCGExData::IDataValue>& Val = VT.Value;
+
+#define PCGEX_SET_VALUE_TAG_ATTR(_TYPE, _NAME) static_cast<FPCGMetadataAttribute<_TYPE>*>(Base)->SetValue(Entry, Val->GetValue<_TYPE>());
+			PCGEX_EXECUTEWITHRIGHTTYPE(Val->GetTypeId(), PCGEX_SET_VALUE_TAG_ATTR)
+#undef PCGEX_SET_VALUE_TAG_ATTR
+		}
+	}
+
+	/** The tag set an actor contributes under the parse mode: raw tags, plain tags, or plain + value-tag names. */
+	inline TSet<FName> BuildEffectiveTags(const AActor* Actor, const EPCGExValueTagMode Mode)
+	{
+		TSet<FName> Tags;
+		if (Mode == EPCGExValueTagMode::NoParsing)
+		{
+			for (const FName& Tag : Actor->Tags)
+			{
+				Tags.Add(Tag);
+			}
+			return Tags;
+		}
+
+		const FParsedActorTags Parsed = ParseActorTags(Actor, nullptr);
+		for (const FName& Tag : Parsed.PlainTags)
+		{
+			Tags.Add(Tag);
+		}
+		if (Mode == EPCGExValueTagMode::ParseAndKeep)
+		{
+			for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
+			{
+				Tags.Add(VT.Key);
+			}
+		}
+		return Tags;
+	}
+
+	/** Comma-joined tag names for the InstanceTags attribute. Empty under Parse (typed attributes carry everything). */
+	inline FString BuildInstanceTagString(const AActor* Actor, const EPCGExValueTagMode Mode)
+	{
+		FString TagsStr;
+		auto Append = [&TagsStr](const FName& Tag)
+		{
+			if (!TagsStr.IsEmpty())
+			{
+				TagsStr += TEXT(",");
+			}
+			TagsStr += Tag.ToString();
+		};
+
+		if (Mode == EPCGExValueTagMode::NoParsing)
+		{
+			for (const FName& Tag : Actor->Tags)
+			{
+				Append(Tag);
+			}
+		}
+		else if (Mode == EPCGExValueTagMode::ParseAndKeep)
+		{
+			const FParsedActorTags Parsed = ParseActorTags(Actor, nullptr);
+			for (const FName& Tag : Parsed.PlainTags)
+			{
+				Append(Tag);
+			}
+			for (const TPair<FName, TSharedPtr<PCGExData::IDataValue>>& VT : Parsed.ValueTags)
+			{
+				Append(VT.Key);
+			}
+		}
+		return TagsStr;
+	}
+}
+
+#endif // WITH_EDITOR

--- a/Source/PCGExCollections/Private/PCGExCollections.cpp
+++ b/Source/PCGExCollections/Private/PCGExCollections.cpp
@@ -5,6 +5,7 @@
 
 #include "Core/PCGExAssetCollectionTypes.h"
 #include "Helpers/PCGExComponentFixups.h"
+#include "Helpers/PCGExLevelExportBuiltinHandlers.h"
 
 #if WITH_EDITOR
 #include "Styling/AppStyle.h"
@@ -25,12 +26,20 @@ void FPCGExCollectionsModule::StartupModule()
 	PCGExAssetCollection::FTypeRegistry::ProcessPendingRegistrations();
 	IPCGExLegacyModuleInterface::StartupModule();
 	PCGExComponentFixups::RegisterBuiltins();
+#if WITH_EDITOR
+	// Level export handlers read their class default objects at registration, so this cannot ride a
+	// static initializer either. Out-of-module handlers register from their own StartupModule.
+	PCGExLevelExport::RegisterBuiltinHandlers();
+#endif
 }
 
 void FPCGExCollectionsModule::ShutdownModule()
 {
 	// Release built-in fixup handles before the delta registry goes out of scope.
 	PCGExComponentFixups::UnregisterBuiltins();
+#if WITH_EDITOR
+	PCGExLevelExport::UnregisterBuiltinHandlers();
+#endif
 	IPCGExLegacyModuleInterface::ShutdownModule();
 }
 

--- a/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
@@ -9,6 +9,7 @@
 #include "Collections/PCGExMeshCollection.h"
 #include "Core/PCGExAssetCollection.h"
 #include "Core/PCGExCollectionTypeState.h"
+#include "Core/PCGExExportSlots.h"
 #include "Helpers/PCGExArrayHelpers.h"
 
 #include "PCGExPCGDataAssetCollection.generated.h"
@@ -53,14 +54,12 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionGlobals : public FPCGExC
  * PCG data asset collection entry. References a UPCGDataAsset or a subcollection.
  * UpdateStaging() computes combined bounds from all spatial data in the asset.
  *
- * Level-sourced entries also feed the parent collection's SharedMeshCollection and
- * SharedLevelCollection by capturing editor-only snapshots (EditorMeshContributions +
- * EditorLocalPicks, EditorLevelContributions + EditorLevelLocalPicks) during export.
- * The captured snapshots are merged into the shared collections by
- * UPCGExPCGDataAssetCollection::CompactSharedMeshFor / CompactSharedLevelFor, which then
- * rewrite each ExportedDataAsset's Tag_EntryIdx attribute on the corresponding pin
- * against the deduplicated shared indices. The CollectionMap pin is rebuilt afterward
- * by RebuildCollectionMapsFor() with all shared + per-entry collections registered.
+ * Export-sourced entries also feed the host's shared collection slots by capturing editor-only
+ * per-slot snapshots (Captures) during export. The captures are merged into the shared slots by
+ * UPCGExPCGDataAssetCollection::CompactSharedFor, which then rewrites each ExportedDataAsset's
+ * Tag_EntryIdx attribute on the corresponding pin against the deduplicated shared indices. The
+ * CollectionMap pin is rebuilt afterward by RebuildCollectionMapsFor() with every shared + per-entry
+ * slot collection registered.
  */
 USTRUCT(BlueprintType, DisplayName="[PCGEx] PCGDataAsset Collection Entry", meta=(ShortName="PCG Data Asset"))
 struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAssetCollectionEntry
@@ -108,66 +107,52 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	UPROPERTY(Instanced)
 	TObjectPtr<UPCGDataAsset> ExportedDataAsset;
 
-	/** Embedded actor collection built by level exporter when bGenerateCollections is enabled.
-	 *  Actor classes are kept per-entry (no cross-entry mutualization). Null in external mode. */
-	UPROPERTY(Instanced)
-	TObjectPtr<UPCGExActorCollection> EmbeddedActorCollection;
-
-	/** External-mode mirrors of ExportedDataAsset / EmbeddedActorCollection. Populated by the
-	 *  externalization step (UPCGExPCGDataAssetCollection::ExternalizeExportedDataAssetsFor /
-	 *  ExternalizeSharedAndActorCollectionsFor). Soft refs so loading the parent collection does
-	 *  not pull these on-disk assets; LoadPCGData soft-loads via Staging.Path / CollectionMap. */
+	/** External-mode mirror of ExportedDataAsset. Populated by the externalization step
+	 *  (UPCGExPCGDataAssetCollection::ExternalizeExportedDataAssetsFor). Soft ref so loading the parent
+	 *  collection does not pull the on-disk asset; LoadPCGData soft-loads via Staging.Path / CollectionMap. */
 	UPROPERTY()
 	TSoftObjectPtr<UPCGDataAsset> ExternalExportedDataAsset;
 
+	/** Per-entry (PerEntry-scope) slot collections built by the exporter -- the actor collection, and any
+	 *  registered handler's per-entry slot. Each slot's Collection is embedded (an inner of ExportedDataAsset)
+	 *  or externalized to its External mirror. Keyed by slot id; no cross-entry mutualization. */
 	UPROPERTY()
-	TSoftObjectPtr<UPCGExActorCollection> ExternalActorCollection;
+	TArray<FPCGExExportCollectionSlot> EmbeddedSlots;
 
 #if WITH_EDITORONLY_DATA
-	/** Snapshot of mesh entries captured from this entry's source level. Editor-only,
-	 *  stripped at cook. Consumed by UPCGExPCGDataAssetCollection::CompactSharedMeshFor
-	 *  as one input to the cross-entry shared-mesh merge. */
-	UPROPERTY()
-	TArray<FPCGExMeshCollectionEntry> EditorMeshContributions;
-
-	/** Caller-computed "common-ancestor" inherited-defaults view for this export's contributing
-	 *  actors -- i.e., per property, the value the actors would resolve if they had no per-instance
-	 *  override. When all unique BP classes agree at the CDO level, that's the CDO value; when
-	 *  they disagree, the asset's authored default fills in. Transient -- recomputed on every
-	 *  export from the actors in this entry's source level. Consumed by CompactSharedMeshFor to
-	 *  derive the shared MeshCollection's CollectionProperties as a per-property union across all
-	 *  contributing entries' aggregates. */
-	UPROPERTY(Transient)
-	TArray<FInstancedStruct> EditorMeshInheritedDefaults;
-
-	/** Per-mesh-point packed local selection, parallel to ExportedDataAsset's "Meshes" pin.
-	 *  Layout: low 16 bits = local entry index into EditorMeshContributions,
-	 *  high 16 bits = secondary index + 1 (0 = no variant; matches FPickPacker convention).
-	 *  Sentinel value -1 means "no valid pick" (point gets no Tag_EntryIdx hash).
+	/** Shared-scope captures from this entry's last export, one per slot (meshes, levels, ...). Consumed
+	 *  by UPCGExPCGDataAssetCollection::CompactSharedFor as one input to the cross-entry merge.
 	 *
-	 *  Persisted (NOT Transient) on purpose: when ANY sibling entry rebuilds and shifts shared
-	 *  composition, every other entry's Tag_EntryIdx must be rewritten. Storing local picks here
-	 *  lets the rewrite pass run without re-walking source levels -- it just reads local picks,
-	 *  applies the new LocalToShared map, and writes final hashes. Stripped at cook. */
+	 *  Persisted (NOT Transient) on purpose: when ANY sibling entry rebuilds and shifts shared composition,
+	 *  every other entry's Tag_EntryIdx must be rewritten. Storing the captures here lets the rewrite pass
+	 *  run without re-walking source levels -- it just reads local picks, applies the new LocalToShared map,
+	 *  and writes final hashes. Stripped at cook. */
 	UPROPERTY()
-	TArray<int32> EditorLocalPicks;
+	TArray<FPCGExExportSlotCapture> Captures;
+#endif
 
-	/** Snapshot of level entries (nested level instances) captured from this entry's source
-	 *  level. Editor-only, stripped at cook. Consumed by
-	 *  UPCGExPCGDataAssetCollection::CompactSharedLevelFor as one input to the cross-entry
-	 *  shared-level merge. */
-	UPROPERTY()
-	TArray<FPCGExLevelCollectionEntry> EditorLevelContributions;
+	// ----- Deprecated slots (2026-09-02): fixed mesh/level/actor storage became keyed slots. -----
+	// UHT registers these under their unsuffixed names with CPF_Deprecated: legacy assets LOAD into them,
+	// saves always skip them. OnHostPostLoad moves the values into EmbeddedSlots / Captures.
 
-	/** Per-level-point packed local selection, parallel to ExportedDataAsset's "Levels" pin.
-	 *  Layout: identity packing of the local entry index into EditorLevelContributions
-	 *  (no secondary dimension on levels yet). Sentinel -1 means "no valid pick".
-	 *
-	 *  Persisted for the same reason as EditorLocalPicks: when sibling-entry composition
-	 *  shifts SharedLevelCollection indices, the rewrite pass reads local picks and applies
-	 *  the new LocalToShared map without re-walking source levels. Stripped at cook. */
+	UPROPERTY(Instanced)
+	TObjectPtr<UPCGExActorCollection> EmbeddedActorCollection_DEPRECATED;
+
 	UPROPERTY()
-	TArray<int32> EditorLevelLocalPicks;
+	TSoftObjectPtr<UPCGExActorCollection> ExternalActorCollection_DEPRECATED;
+
+#if WITH_EDITORONLY_DATA
+	UPROPERTY()
+	TArray<FPCGExMeshCollectionEntry> EditorMeshContributions_DEPRECATED;
+
+	UPROPERTY()
+	TArray<int32> EditorLocalPicks_DEPRECATED;
+
+	UPROPERTY()
+	TArray<FPCGExLevelCollectionEntry> EditorLevelContributions_DEPRECATED;
+
+	UPROPERTY()
+	TArray<int32> EditorLevelLocalPicks_DEPRECATED;
 #endif
 
 	// Lifecycle
@@ -175,6 +160,7 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	virtual bool Validate(const UPCGExAssetCollection* ParentCollection) override;
 	virtual void UpdateStaging(const UPCGExAssetCollection* OwningCollection, int32 InInternalIndex, bool bRecursive) override;
 	virtual void SetAssetPath(const FSoftObjectPath& InPath) override;
+	virtual bool OnHostPostLoad(UPCGExAssetCollection* Host) override;
 
 #if WITH_EDITOR
 	virtual void EDITOR_Sanitize() override;
@@ -183,12 +169,16 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 	virtual FSoftObjectPath EDITOR_GetActivationAssetPath() const override;
 #endif
 
+	/** Embedded per-entry slot collection by id, or null. Legacy accessor for the actor slot: FindEmbeddedSlot(Actors). */
+	UPCGExAssetCollection* FindEmbeddedCollection(FName SlotId) const;
+
 private:
 	/** Level and Actor sources share everything past the load: export into a fresh embedded asset,
 	 *  capture contributions, scan sockets. Returns false when the export produced nothing. */
 	bool ExportFromSource(const UPCGExAssetCollection* OwningCollection, const FPCGExLevelExportSource& ExportSource);
 
-	/** Editor-only capture buffers -- every reset site in UpdateStaging goes through here. */
+	/** Editor-only capture buffers -- every reset site in UpdateStaging goes through here. Retires any
+	 *  instanced subobjects the captured entries owned. */
 	void ResetEditorContributions();
 
 	/** Staging + embedded export back to "nothing" -- a failed or impossible export. */
@@ -197,13 +187,11 @@ private:
 
 /** Concrete collection for UPCGDataAsset references with optional level-sourced entries.
  *
- *  Mutualizes mesh + nested-level storage across level-sourced entries via the machinery
- *  state's SharedMeshCollection and SharedLevelCollection: each entry's per-level snapshots
- *  (EditorMeshContributions, EditorLevelContributions) are captured during export, then
- *  merged into the two shared collections (CompactSharedMeshFor, CompactSharedLevelFor).
- *  Per-entry ExportedDataAsset point hashes resolve through the shared collections'
- *  CollectionGUIDs at runtime, eliminating duplicated storage when entries reuse the same
- *  meshes or the same nested levels.
+ *  Mutualizes shared-scope slot storage (meshes, nested levels, and any registered handler's shared
+ *  slot) across export-sourced entries via the machinery state's SharedSlots: each entry's per-slot
+ *  captures are taken during export, then merged per slot (CompactSharedFor). Per-entry
+ *  ExportedDataAsset point hashes resolve through the shared collections' CollectionGUIDs at runtime,
+ *  eliminating duplicated storage when entries reuse the same meshes, levels or sketches.
  *
  *  Phase C1 (per-type processor seam): the machinery storage + external-storage settings
  *  live on an owned UPCGExPCGDataTypeState (always present, default subobject) and every
@@ -211,16 +199,15 @@ private:
  *  state is guaranteed, running the exact same code path as an Omni host. Legacy members
  *  migrate into the state on PostLoad (deprecated slots below).
  *
- *  Actor classes are kept per-entry on Entry.EmbeddedActorCollection (no cross-entry merge).
+ *  Per-entry slots (actors) are kept on Entry.EmbeddedSlots (no cross-entry merge).
  */
 
 /**
  * Host-agnostic view over the state the PCGDataAsset collection machinery operates on
- * (shared-collection compaction, collection maps, externalization). Phase A of the per-type
- * processor seam: the typed collection composes this from its own members (MakeMachinery);
- * heterogeneous hosts will compose it from per-type state blocks in a later phase.
+ * (shared-slot compaction, collection maps, externalization). The typed collection composes it
+ * from its own state (MakeMachinery); heterogeneous hosts compose it from their per-type state.
  *
- * Storage members are POINTERS TO the host's storage so the cores mutate the real refs.
+ * SharedSlots POINTS TO the host state's storage so the cores mutate the real refs.
  * Entries is the PCGData-typed LEAF payload view in host order -- external-asset naming uses
  * the view index, which matches the raw entry index on typed collections.
  */
@@ -229,10 +216,7 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetMachinery
 	UPCGExAssetCollection* Host = nullptr; // Outer for generated subobjects; GUID / package identity
 	TArray<FPCGExPCGDataAssetCollectionEntry*> Entries;
 
-	TObjectPtr<UPCGExMeshCollection>* SharedMeshCollection = nullptr;
-	TObjectPtr<UPCGExLevelCollection>* SharedLevelCollection = nullptr;
-	TSoftObjectPtr<UPCGExMeshCollection>* ExternalSharedMeshCollection = nullptr;
-	TSoftObjectPtr<UPCGExLevelCollection>* ExternalSharedLevelCollection = nullptr;
+	TArray<FPCGExExportCollectionSlot>* SharedSlots = nullptr;
 
 	bool bExternalActive = false;
 	FString ExportFolderPath;
@@ -240,8 +224,7 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetMachinery
 
 	bool IsValid() const
 	{
-		return Host && SharedMeshCollection && SharedLevelCollection
-			&& ExternalSharedMeshCollection && ExternalSharedLevelCollection;
+		return Host && SharedSlots;
 	}
 };
 
@@ -253,30 +236,28 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetMachinery
  */
 struct PCGEXCOLLECTIONS_API FPCGExPCGDataSharedScrubKeep
 {
-	TObjectPtr<UPCGExMeshCollection>* MeshSlot = nullptr;
-	TObjectPtr<UPCGExLevelCollection>* LevelSlot = nullptr;
-	TObjectPtr<UPCGExMeshCollection> KeptMesh;
-	TObjectPtr<UPCGExLevelCollection> KeptLevel;
+	TArray<FPCGExExportCollectionSlot>* Slots = nullptr;
+	TArray<TObjectPtr<UPCGExAssetCollection>> Kept;
 };
 
 struct PCGEXCOLLECTIONS_API FPCGExPCGDataEntryScrubKeep
 {
 	TArray<FPCGExPCGDataAssetCollectionEntry*> Entries;
 	TArray<TObjectPtr<UPCGDataAsset>> Data;
-	TArray<TObjectPtr<UPCGExActorCollection>> Actors;
+	TArray<TArray<TObjectPtr<UPCGExAssetCollection>>> Embedded;
 
 	void Reset()
 	{
 		Entries.Reset();
 		Data.Reset();
-		Actors.Reset();
+		Embedded.Reset();
 	}
 };
 
 /**
  * Machinery state/processor for PCGDataAsset-typed entries hosted OUTSIDE a native
  * PCGDataAsset collection (per-type processor seam, Phase B). Owns the same shared/external
- * storage the typed collection keeps as members -- names mirror 1:1 -- and dispatches the
+ * storage the typed collection keeps -- keyed collection slots -- and dispatches the
  * host-agnostic machinery cores against it from the host lifecycle hooks. With this state
  * present, level-sourced entries in an Omni behave like they do in a native collection
  * (export, compaction, collection maps, externalization).
@@ -295,22 +276,49 @@ public:
 	UPROPERTY(EditAnywhere, Category = "External Storage", meta=(EditCondition="bUseExternalAssets", ContentDir, LongPackageName))
 	FDirectoryPath ExportFolder;
 
-	UPROPERTY(Instanced)
-	TObjectPtr<UPCGExMeshCollection> SharedMeshCollection;
+	/** Shared-scope slot collections (meshes, levels, and any registered handler's shared slot), keyed
+	 *  by slot id. Each Collection is an embedded working buffer outered to the host, or externalized
+	 *  to its External mirror. */
+	UPROPERTY()
+	TArray<FPCGExExportCollectionSlot> SharedSlots;
+
+	// ----- Deprecated slots (2026-09-02): the fixed mesh/level members became keyed SharedSlots. -----
+	// Legacy data loads into these (CPF_Deprecated: tagged-property name match, saves skip); PostLoad
+	// adopts them into SharedSlots once.
 
 	UPROPERTY(Instanced)
-	TObjectPtr<UPCGExLevelCollection> SharedLevelCollection;
+	TObjectPtr<UPCGExMeshCollection> SharedMeshCollection_DEPRECATED;
+
+	UPROPERTY(Instanced)
+	TObjectPtr<UPCGExLevelCollection> SharedLevelCollection_DEPRECATED;
 
 	UPROPERTY()
-	TSoftObjectPtr<UPCGExMeshCollection> ExternalSharedMeshCollection;
+	TSoftObjectPtr<UPCGExMeshCollection> ExternalSharedMeshCollection_DEPRECATED;
 
 	UPROPERTY()
-	TSoftObjectPtr<UPCGExLevelCollection> ExternalSharedLevelCollection;
+	TSoftObjectPtr<UPCGExLevelCollection> ExternalSharedLevelCollection_DEPRECATED;
 
 	bool IsExternalActive() const
 	{
 		return bUseExternalAssets && !ExportFolder.Path.IsEmpty();
 	}
+
+	FPCGExExportCollectionSlot* FindSharedSlot(const FName SlotId)
+	{
+		return PCGExExportSlots::Find(SharedSlots, SlotId);
+	}
+
+	const FPCGExExportCollectionSlot* FindSharedSlot(const FName SlotId) const
+	{
+		return PCGExExportSlots::Find(SharedSlots, SlotId);
+	}
+
+	/**
+	 * Adopt a legacy fixed-member pair into the keyed slot. Idempotent and order-agnostic: both the
+	 * host's PostLoad (pre-C1 members) and this object's PostLoad (C1 members) funnel through here, and
+	 * whichever runs first wins nothing -- a slot already holding data is left alone.
+	 */
+	void AdoptLegacySlot(FName SlotId, UPCGExAssetCollection* Collection, const FSoftObjectPath& External);
 
 	/**
 	 * Compose the machinery view: HOST identity (outer/GUID) + THIS state's storage + the
@@ -357,6 +365,9 @@ public:
 	 *  their instanced refs must not bake hard references into the saved package. Entry-level
 	 *  refs live in HOST data and are scrubbed by the OnHostSerializeSave pair instead. */
 	virtual void Serialize(FArchive& Ar) override;
+
+	/** Legacy fixed members -> SharedSlots. */
+	virtual void PostLoad() override;
 
 private:
 	/** OnHostSerializeSave_Begin/End restore buffer -- see FPCGExPCGDataEntryScrubKeep. */
@@ -452,9 +463,9 @@ private:
 
 public:
 	/**
-	 * Manual convenience: recompact both shared collections (mesh + level) from each entry's
-	 * captured editor-only contributions, rewrite per-entry Tag_EntryIdx against the
-	 * resulting shared indices, and rebuild every entry's CollectionMap pin. Idempotent.
+	 * Manual convenience: recompact every shared slot from each entry's captured editor-only
+	 * contributions, rewrite per-entry Tag_EntryIdx against the resulting shared indices, and
+	 * rebuild every entry's CollectionMap pin. Idempotent.
 	 * The automatic paths (post-staging rebuild, cook-time PreSave net, PostDuplicate
 	 * re-stamp) do NOT route through this -- they dispatch through MachineryState's
 	 * lifecycle hooks directly; this exists for explicit tooling-driven recompaction.
@@ -465,26 +476,27 @@ public:
 	// host that can compose a FPCGExPCGDataAssetMachinery can run them (per-type processor
 	// seam, Phase A). The private instance methods below are thin wrappers over these.
 	// All editor-only in effect: bodies guard on WITH_EDITOR(_DATA) like their predecessors.
-	static void CompactSharedMeshFor(FPCGExPCGDataAssetMachinery& State);
-	static void CompactSharedLevelFor(FPCGExPCGDataAssetMachinery& State);
+
+	/** Every registered Shared-scope slot: merge captures, rewrite the slot pin's Tag_EntryIdx. */
+	static void CompactSharedFor(FPCGExPCGDataAssetMachinery& State);
 	static void RebuildCollectionMapsFor(FPCGExPCGDataAssetMachinery& State);
-	static void ExternalizeSharedAndActorCollectionsFor(FPCGExPCGDataAssetMachinery& State);
+	/** Shared slots -> <Prefix>_<SlotId>; per-entry slots -> <Prefix>_E%03d_<SlotId>. */
+	static void ExternalizeSlotCollectionsFor(FPCGExPCGDataAssetMachinery& State);
 	static void ExternalizeExportedDataAssetsFor(FPCGExPCGDataAssetMachinery& State);
 	static void InternalizeSubobjectsFor(FPCGExPCGDataAssetMachinery& State);
 	static void SaveExternalPackagesFor(FPCGExPCGDataAssetMachinery& State);
 
 	/** Shared package-collection walk over the machinery storage: the loaded packages the
-	 *  shared collections and per-entry exports currently live in, minus the host's own and
+	 *  shared slots and per-entry exports currently live in, minus the host's own and
 	 *  the transient package (so embedded mode contributes nothing). Drives both the manual
 	 *  SaveExternalPackages utility and the editor-save coordination seam. */
 	static void CollectExternalPackagesFor(
 		const UPCGExAssetCollection* Host,
-		const UPCGExMeshCollection* InSharedMesh,
-		const UPCGExLevelCollection* InSharedLevel,
+		const TArray<FPCGExExportCollectionSlot>& InSharedSlots,
 		const TArray<const FPCGExPCGDataAssetCollectionEntry*>& InEntries,
 		TSet<UPackage*>& OutPackages);
 
-	/** Orchestrator: compaction -> shared/actor externalization -> collection maps -> data
+	/** Orchestrator: compaction -> shared/per-entry externalization -> collection maps -> data
 	 *  asset externalization, in the order the soft-path baking requires. */
 	static void RebuildSharedCollectionsFor(FPCGExPCGDataAssetMachinery& State);
 
@@ -497,9 +509,9 @@ public:
 	/** External-mode save-scrub cores (see Serialize). Scrub* records the slots and current
 	 *  values into the keep-buffer and nulls the live refs; Restore* writes them back and
 	 *  resets the buffer. The pair must bracket exactly one Serialize call on one thread.
-	 *  Shared refs = the two shared collections; entry refs = each entry's ExportedDataAsset +
-	 *  EmbeddedActorCollection. Any future externalizable ref is added HERE, for every host. */
-	static void ScrubSharedRefsForSave(TObjectPtr<UPCGExMeshCollection>& MeshSlot, TObjectPtr<UPCGExLevelCollection>& LevelSlot, FPCGExPCGDataSharedScrubKeep& OutKeep);
+	 *  Shared refs = every shared slot collection; entry refs = each entry's ExportedDataAsset +
+	 *  every embedded slot collection. */
+	static void ScrubSharedRefsForSave(TArray<FPCGExExportCollectionSlot>& Slots, FPCGExPCGDataSharedScrubKeep& OutKeep);
 	static void RestoreSharedRefsAfterSave(FPCGExPCGDataSharedScrubKeep& Keep);
 	static void ScrubEntryRefsForSave(const TArray<FPCGExPCGDataAssetCollectionEntry*>& InEntries, FPCGExPCGDataEntryScrubKeep& OutKeep);
 	static void RestoreEntryRefsAfterSave(FPCGExPCGDataEntryScrubKeep& Keep);
@@ -510,10 +522,7 @@ public:
 	 *  callers are const contexts and the machinery view is a mutation view. See
 	 *  GetCookDependencyAssetPaths for the embedded-vs-external rationale per block. */
 	static void AppendCookDependencyAssetPathsFor(
-		const UPCGExMeshCollection* InSharedMesh,
-		const UPCGExLevelCollection* InSharedLevel,
-		const TSoftObjectPtr<UPCGExMeshCollection>& InExternalSharedMesh,
-		const TSoftObjectPtr<UPCGExLevelCollection>& InExternalSharedLevel,
+		const TArray<FPCGExExportCollectionSlot>& InSharedSlots,
 		const TArray<const FPCGExPCGDataAssetCollectionEntry*>& InEntries,
 		TSet<FSoftObjectPath>& OutPaths);
 #endif
@@ -544,8 +553,8 @@ public:
 
 	/**
 	 * Cook-path override -- adds the references that GetAssetPaths intentionally omits
-	 * (those are reserved for runtime cherry-picking). Walks embedded shared / actor
-	 * subcollections so their leaf soft refs reach the cook, and surfaces the
+	 * (those are reserved for runtime cherry-picking). Walks embedded shared / per-entry
+	 * slot collections so their leaf soft refs reach the cook, and surfaces the
 	 * externalized-package soft paths so their on-disk assets cook too.
 	 *
 	 * Assumes external assets exist on disk from a prior editor save -- the normal

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -1067,8 +1067,8 @@ public:
 	 * schema needs to mirror them. Counterpart to UPCGExActorCollection's actor-component
 	 * scan, which builds the schema from the component side. Callers:
 	 *
-	 *   - SharedMeshCollection after CompactSharedMesh has aggregated per-entry mesh
-	 *     contributions (each contribution may carry its own PropertyOverrides extracted
+	 *   - A shared slot collection after CompactSharedFor has aggregated per-entry export
+	 *     captures (each captured entry may carry its own PropertyOverrides extracted
 	 *     from the source actor's UPCGExPropertyCollectionComponent).
 	 *   - Anywhere else a collection's schema should be reconstructed from the data
 	 *     authored on individual entries.

--- a/Source/PCGExCollections/Public/Core/PCGExCollectionHelpers.h
+++ b/Source/PCGExCollections/Public/Core/PCGExCollectionHelpers.h
@@ -137,5 +137,21 @@ namespace PCGExCollectionHelpers
 	 */
 	PCGEXCOLLECTIONS_API
 	void DuplicateInstancedSubobjects(const UScriptStruct* Struct, void* StructMemory, UObject* NewOuter);
+
+	/**
+	 * Move a struct's Instanced subobjects to the transient package and null the refs. For entries about
+	 * to be overwritten: an unreferenced inner left under its outer still shows up in save-time traversal.
+	 * Top-level properties only, like DuplicateInstancedSubobjects.
+	 */
+	PCGEXCOLLECTIONS_API
+	void RetireInstancedSubobjects(const UScriptStruct* Struct, void* StructMemory);
+
+	/**
+	 * Rename a struct's Instanced subobjects under NewOuter (no copy). For subobjects the struct is the
+	 * SOLE owner of -- freshly minted by an export handler -- where a duplicate would only leave an
+	 * orphan behind. Top-level properties only.
+	 */
+	PCGEXCOLLECTIONS_API
+	void ReparentInstancedSubobjects(const UScriptStruct* Struct, void* StructMemory, UObject* NewOuter);
 #endif
 }

--- a/Source/PCGExCollections/Public/Core/PCGExExportSlots.h
+++ b/Source/PCGExCollections/Public/Core/PCGExExportSlots.h
@@ -1,0 +1,88 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "StructUtils/InstancedStruct.h"
+#include "UObject/ObjectPtr.h"
+#include "UObject/SoftObjectPtr.h"
+
+#include "PCGExExportSlots.generated.h"
+
+class UPCGExAssetCollection;
+
+/**
+ * One export handler's hand-off for a Shared-scope slot, captured per PCGDataAsset entry during
+ * export and merged across sibling entries by the shared compaction. Persisted (editor-only) so a
+ * sibling rebuild can recompact without re-walking this entry's source.
+ */
+USTRUCT()
+struct PCGEXCOLLECTIONS_API FPCGExExportSlotCapture
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	FName SlotId = NAME_None;
+
+	/** Entry snapshots of the slot's registered EntryStruct, in local-index order. */
+	UPROPERTY()
+	TArray<FInstancedStruct> Entries;
+
+	/** One int32 per point on the slot's pin: -1 = no pick; else a local entry index, packed with the
+	 *  secondary index when the slot supports secondaries (FPCGExLevelExportContext::PackLocalPick). */
+	UPROPERTY()
+	TArray<int32> LocalPicks;
+
+	/** Per-property "inherited defaults" view aggregated by the handler (mesh property components).
+	 *  Recomputed on every export; feeds the shared collection's CollectionProperties. */
+	UPROPERTY(Transient)
+	TArray<FInstancedStruct> InheritedDefaults;
+};
+
+/**
+ * One collection slot of the PCGDataAsset machinery: embedded working object plus its externalized
+ * mirror. Held per entry for PerEntry-scope slots and on the type state for Shared-scope slots.
+ * Collection is null in external mode once externalized (see ExternalizeSlotCollectionsFor).
+ */
+USTRUCT()
+struct PCGEXCOLLECTIONS_API FPCGExExportCollectionSlot
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	FName SlotId = NAME_None;
+
+	UPROPERTY(Instanced)
+	TObjectPtr<UPCGExAssetCollection> Collection;
+
+	UPROPERTY()
+	TSoftObjectPtr<UPCGExAssetCollection> External;
+};
+
+namespace PCGExExportSlots
+{
+	template <typename TSlot>
+	TSlot* Find(TArray<TSlot>& Slots, const FName SlotId)
+	{
+		return Slots.FindByPredicate([SlotId](const TSlot& S) { return S.SlotId == SlotId; });
+	}
+
+	template <typename TSlot>
+	const TSlot* Find(const TArray<TSlot>& Slots, const FName SlotId)
+	{
+		return Slots.FindByPredicate([SlotId](const TSlot& S) { return S.SlotId == SlotId; });
+	}
+
+	template <typename TSlot>
+	TSlot& FindOrAdd(TArray<TSlot>& Slots, const FName SlotId)
+	{
+		if (TSlot* Found = Find(Slots, SlotId))
+		{
+			return *Found;
+		}
+		TSlot& Added = Slots.AddDefaulted_GetRef();
+		Added.SlotId = SlotId;
+		return Added;
+	}
+}

--- a/Source/PCGExCollections/Public/Helpers/PCGExDefaultLevelDataExporter.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExDefaultLevelDataExporter.h
@@ -14,7 +14,17 @@
 #include "PCGExDefaultLevelDataExporter.generated.h"
 
 class AActor;
+class UPCGBasePointData;
+class UPCGExLevelExportHandler;
 class UStaticMeshComponent;
+
+#if WITH_EDITOR
+class FPCGExExportSlotWriter;
+namespace PCGExLevelExport
+{
+	struct FHandlerRegistration;
+}
+#endif
 
 UENUM()
 enum class EPCGExValueTagMode : uint8
@@ -45,14 +55,17 @@ enum class EPCGExActorExportType : uint8
  * Default level data exporter that replicates the engine's UPCGLevelToAsset behavior.
  *
  * For each qualifying actor of the export source (a whole level, or one actor's subtree):
- * - Classifies actors as Mesh or Actor (or Skip)
- * - Creates a point at the actor's transform
- * - Stores mesh/actor references, materials, and bounds as metadata attributes
- * - Organizes output as typed tagged data entries ("Meshes", "Actors")
+ * - Classifies actors as Mesh, Actor or Level (or Skip) -- unless a registered export handler claims
+ *   the actor first (see UPCGExLevelExportHandler)
+ * - Hands every candidate (the subtree root included) to every export handler; the built-in Mesh /
+ *   Actor / Level handlers harvest the actors classified into their slot
+ * - Emits one point data per slot on that slot's pin, with the actor's transform, bounds, name and
+ *   value tags as metadata
  *
- * When bGenerateCollections is enabled, raw metadata is replaced with collection entry
- * hashes (int64 PCGEx/CollectionEntry), and embedded mesh/actor collections are built
- * for downstream consumption via Collection Map.
+ * When bGenerateCollections is enabled, raw metadata is replaced with collection entry hashes
+ * (int64 PCGEx/CollectionEntry): per-entry slots (actors) are built into embedded collections here;
+ * shared slots (meshes, levels, ...) are handed back as captures for the collection's cross-entry
+ * compaction, which writes their hashes and the Collection Map.
  *
  * Skips: hidden actors, editor-only actors, level script actors, info actors, brushes.
  * Supports tag/class include/exclude filtering (same pattern as level collection bounds).
@@ -100,6 +113,11 @@ public:
 	UPROPERTY(EditAnywhere, Category = Settings, meta=(EditCondition="bGenerateCollections"))
 	EPCGExSchemaMergePolicy SchemaMergePolicy = EPCGExSchemaMergePolicy::StrictTypeMatch;
 
+	/** Run every export handler registered by other modules (e.g. cluster sketches). Off keeps only the
+	 *  built-in Mesh / Actor / Level handlers. */
+	UPROPERTY(EditAnywhere, Category = Settings)
+	bool bUseRegisteredHandlers = true;
+
 	/** Controls how actor tags in the form Name:Value are handled.
 	 *  Parse: plain tags → bool=true attributes; Name:Value tags → typed attributes; tag string not written.
 	 *  ParseAndKeep: same as Parse, but the name-part of each value tag is also included in the tag string.
@@ -129,9 +147,20 @@ public:
 	 *  An actor is either an Actor (full identity, property delta, etc.) or a Mesh
 	 *  container (every SMC-derived component is harvested). The two are mutually
 	 *  exclusive -- Actor-classified actors do NOT contribute mesh points, even when
-	 *  they own ISMCs. */
+	 *  they own ISMCs. Registered handlers get to claim an actor BEFORE this runs. */
 	virtual EPCGExActorExportType ClassifyActor(AActor* Actor) const;
 
 	/** Called after all points are created, before collection generation. */
 	virtual void OnExportComplete(UPCGDataAsset* OutAsset);
+
+#if WITH_EDITOR
+
+private:
+	/** Point data for one slot's items on its pin: transform, bounds, ActorName, value tags, handler attributes. */
+	UPCGBasePointData* EmitSlotPoints(const FPCGExExportSlotWriter& Writer, const UPCGExLevelExportHandler* Handler, UPCGDataAsset* OutAsset) const;
+
+	/** PerEntry slot: (re)build the embedded collection from the writer and write its picks on the pin. */
+	void BuildEmbeddedSlot(const PCGExLevelExport::FHandlerRegistration& Registration, FPCGExExportSlotWriter& Writer, UPCGDataAsset* OutAsset, UPCGBasePointData* PointData, FPCGExLevelExportContext& OutContext) const;
+
+#endif
 };

--- a/Source/PCGExCollections/Public/Helpers/PCGExLevelDataExporter.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExLevelDataExporter.h
@@ -4,17 +4,14 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "StructUtils/InstancedStruct.h"
+#include "Core/PCGExExportSlots.h"
 #include "UObject/Object.h"
 
 #include "PCGExLevelDataExporter.generated.h"
 
 class AActor;
 class UPCGDataAsset;
-class UPCGExActorCollection;
 class UWorld;
-struct FPCGExMeshCollectionEntry;
-struct FPCGExLevelCollectionEntry;
 
 /**
  * What a level export reads: a world, the actors to consider, and the frame the output is expressed
@@ -58,56 +55,42 @@ struct PCGEXCOLLECTIONS_API FPCGExLevelExportSource
 /**
  * Output state populated by UPCGExLevelDataExporter::ExportLevelData (rich C++ overload).
  *
- * Assign the output pointers before calling the 3-arg ExportLevelData. The exporter never
- * builds inline UPCGExMeshCollection / UPCGExLevelCollection and never writes Tag_EntryIdx
- * or the CollectionMap pin itself -- it captures contributions through these pointers and
- * leaves final hashing + CollectionMap emission to the caller.
+ * Assign the storage pointers before calling the 3-arg ExportLevelData. The exporter never builds
+ * shared collections, never writes Tag_EntryIdx for shared slots and never emplaces the CollectionMap
+ * pin -- it hands shared-slot contributions back as captures (one per slot) and leaves final hashing +
+ * CollectionMap emission to the caller. Per-entry slots are built into Embedded collections here,
+ * reusing the previous object found under the same slot id (its CollectionGUID and EntryIds survive).
  *
- * MeshLocalPicks layout (one int32 per "Meshes" pin point):
- *   low 16 bits  = local entry index into MeshContributions
+ * LocalPicks layout (one int32 per point on the slot's pin):
+ *   low 16 bits  = local entry index into the capture's Entries
  *   high 16 bits = secondary index + 1 (0 = no variant; matches FPickPacker hash convention)
  *   value == -1  = sentinel, no valid pick for this point
+ * Slots without secondaries pack (local, -1), i.e. the high half is 0.
  *
- * LevelLocalPicks layout (one int32 per "Levels" pin point):
- *   value        = local entry index into LevelContributions (no secondary on levels yet)
- *   value == -1  = sentinel, no valid pick for this point
- *
- * Consumed by UPCGExPCGDataAssetCollection's shared-collection rebuild to merge contributions
- * across sibling entries and rewrite Tag_EntryIdx hashes against the deduplicated collections.
+ * Consumed by UPCGExPCGDataAssetCollection's shared-collection rebuild to merge captures across
+ * sibling entries and rewrite Tag_EntryIdx hashes against the deduplicated collections.
  */
 struct PCGEXCOLLECTIONS_API FPCGExLevelExportContext
 {
-	TArray<FPCGExMeshCollectionEntry>* MeshContributions = nullptr;
-	TArray<int32>* MeshLocalPicks = nullptr;
+	/** Shared-scope hand-off, one capture per slot. Null = shared contributions are not captured. */
+	TArray<FPCGExExportSlotCapture>* Captures = nullptr;
 
-	TArray<FPCGExLevelCollectionEntry>* LevelContributions = nullptr;
-	TArray<int32>* LevelLocalPicks = nullptr;
+	/** Per-entry slots: previous embedded collections in, rebuilt ones out. Null = built but not handed back. */
+	TArray<FPCGExExportCollectionSlot>* EmbeddedSlots = nullptr;
 
-	/** Receives the per-entry actor collection built inline by the exporter. Lets the caller
-	 *  pick it up directly instead of walking the asset's inner-object graph. */
-	TObjectPtr<UPCGExActorCollection>* ActorCollectionOut = nullptr;
+	/** Owner the captures are serialized under (the host collection). Instanced subobjects inside
+	 *  captured entries are outered here so they never cross packages when the export is externalized.
+	 *  Null falls back to the exported asset. */
+	UObject* CaptureOuter = nullptr;
 
-	/** Previous per-entry actor collection, when one exists. Reused as the working buffer
-	 *  (re-outered to the new asset) so its CollectionGUID and EntryIds survive re-exports.
-	 *  The caller keeps it GC-reachable for the duration of the call. */
-	UPCGExActorCollection* PreviousActorCollection = nullptr;
-
-	/** Receives the "common-ancestor" inherited-defaults view computed from the contributing
-	 *  actors' BP class chains -- per property, the value all unique classes agree on at the
-	 *  CDO level, or the asset's authored default when classes disagree. Used by the shared
-	 *  MeshCollection rebuild to set CollectionProperties without falling back to whichever
-	 *  per-instance override was iterated first. Optional: when null, the caller has no opinion
-	 *  and the merge falls through to per-entry contributors. */
-	TArray<FInstancedStruct>* MeshInheritedDefaults = nullptr;
-
-	/** Pack a (local entry index, secondary index) pair into the int32 stored in MeshLocalPicks. */
+	/** Pack a (local entry index, secondary index) pair into the int32 stored in LocalPicks. */
 	static FORCEINLINE int32 PackLocalPick(int32 LocalEntryIdx, int16 SecondaryIdx)
 	{
 		const int32 SecPlus1 = (static_cast<int32>(SecondaryIdx) + 1) & 0xFFFF;
 		return (SecPlus1 << 16) | (LocalEntryIdx & 0xFFFF);
 	}
 
-	/** Unpack a MeshLocalPicks value back into local entry index and secondary index. */
+	/** Unpack a LocalPicks value back into local entry index and secondary index. */
 	static FORCEINLINE void UnpackLocalPick(int32 Packed, int32& OutLocalIdx, int16& OutSecondary)
 	{
 		OutLocalIdx = Packed & 0xFFFF;
@@ -130,13 +113,12 @@ struct PCGEXCOLLECTIONS_API FPCGExLevelExportContext
  *    resulting asset carries raw attributes (Mesh / ActorClass / LevelAsset) and no
  *    Tag_EntryIdx / CollectionMap. Standalone use only.
  *  - C++ virtual ExportLevelData(Source, OutAsset, FPCGExLevelExportContext&):
- *    used by UPCGExPCGDataAssetCollection to capture editor-only mesh + level
- *    contributions that feed shared-collection compaction (CompactSharedMesh /
- *    CompactSharedLevel). The exporter never builds inline embedded collections,
- *    never writes Tag_EntryIdx, and never emplaces the CollectionMap pin --
- *    those responsibilities live on the caller. Default impl on the base forwards
- *    to the BP-facing path with the source's world -- a BP exporter always sees the
- *    whole level, never a subtree.
+ *    used by UPCGExPCGDataAssetCollection to capture editor-only per-slot
+ *    contributions that feed shared-collection compaction (CompactSharedFor).
+ *    The exporter never builds shared collections, never writes their Tag_EntryIdx,
+ *    and never emplaces the CollectionMap pin -- those responsibilities live on the
+ *    caller. Default impl on the base forwards to the BP-facing path with the
+ *    source's world -- a BP exporter always sees the whole level, never a subtree.
  */
 UCLASS(Abstract, Blueprintable, BlueprintType, EditInlineNew, DefaultToInstanced, meta=(DisplayName="Level Data Exporter", PCGExNodeLibraryDoc="staging/collections/pcg-data-asset-collection/level-data-exporter"))
 class PCGEXCOLLECTIONS_API UPCGExLevelDataExporter : public UObject
@@ -162,13 +144,13 @@ public:
 
 	/**
 	 * Rich C++-only export entry point. Populates an FPCGExLevelExportContext with
-	 * mesh-entry contributions and per-mesh-point packed local picks for the consumer
-	 * to merge across sibling entries. Every transform written must go through
-	 * Source.ToFrame -- a subtree source is only a level when its output is root-relative.
+	 * per-slot entry captures and packed local picks for the consumer to merge across
+	 * sibling entries. Every transform written must go through Source.ToFrame -- a
+	 * subtree source is only a level when its output is root-relative.
 	 *
-	 * Default implementation forwards to the BP-facing ExportLevelData; mesh
-	 * contributions are not captured in that path. Override in C++ subclasses
-	 * (see UPCGExDefaultLevelDataExporter) to populate the context.
+	 * Default implementation forwards to the BP-facing ExportLevelData; nothing is
+	 * captured in that path. Override in C++ subclasses (see UPCGExDefaultLevelDataExporter)
+	 * to populate the context.
 	 */
 	virtual bool ExportLevelData(const FPCGExLevelExportSource& Source, UPCGDataAsset* OutAsset, FPCGExLevelExportContext& OutContext)
 	{

--- a/Source/PCGExCollections/Public/Helpers/PCGExLevelExportBuiltinHandlers.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExLevelExportBuiltinHandlers.h
@@ -1,0 +1,79 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Helpers/PCGExLevelExportHandler.h"
+
+#include "PCGExLevelExportBuiltinHandlers.generated.h"
+
+/**
+ * The three content kinds the default exporter has always produced, as handlers. None of them
+ * claims: the Mesh / Actor / Level split stays UPCGExDefaultLevelDataExporter::ClassifyActor's
+ * (overridable) decision; each handler harvests the candidates classified into its slot. Registered
+ * by FPCGExCollectionsModule::StartupModule.
+ */
+
+/** Static-mesh components of Mesh-classified actors -> "Meshes" pin, shared mesh collection. */
+UCLASS()
+class PCGEXCOLLECTIONS_API UPCGExMeshExportHandler : public UPCGExLevelExportHandler
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FPCGExExportSlotDesc GetSlotDesc() const override;
+	virtual TSharedPtr<const IPCGExExportSlotPolicy> MakePolicy() const override;
+	virtual int32 GetPriority() const override { return 10; }
+	virtual void Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const override;
+	virtual void FinalizeSlot(FPCGExExportSlotWriter& Writer, UObject* Outer, const UPCGExLevelDataExporter* Exporter) const override;
+	virtual void WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const override;
+#endif
+};
+
+/** Actor-classified actors -> "Actors" pin, per-entry actor collection (class + property delta). */
+UCLASS()
+class PCGEXCOLLECTIONS_API UPCGExActorExportHandler : public UPCGExLevelExportHandler
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FPCGExExportSlotDesc GetSlotDesc() const override;
+	virtual TSharedPtr<const IPCGExExportSlotPolicy> MakePolicy() const override;
+	virtual int32 GetPriority() const override { return 20; }
+	virtual void Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const override;
+	virtual void WriteItemAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const override;
+	virtual void WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const override;
+	virtual void FinalizeEmbeddedCollection(UPCGExAssetCollection* Collection, FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const override;
+#endif
+};
+
+/** Level instances -> "Levels" pin, shared level collection. */
+UCLASS()
+class PCGEXCOLLECTIONS_API UPCGExLevelInstanceExportHandler : public UPCGExLevelExportHandler
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FPCGExExportSlotDesc GetSlotDesc() const override;
+	virtual TSharedPtr<const IPCGExExportSlotPolicy> MakePolicy() const override;
+	virtual int32 GetPriority() const override { return 30; }
+	virtual void Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const override;
+	virtual void WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const override;
+#endif
+};
+
+#if WITH_EDITOR
+namespace PCGExLevelExport
+{
+	/** Registers the three built-in handlers. Called once from the Collections module startup. */
+	PCGEXCOLLECTIONS_API void RegisterBuiltinHandlers();
+	PCGEXCOLLECTIONS_API void UnregisterBuiltinHandlers();
+
+	/** True for the three built-in handler classes (what bUseRegisteredHandlers == false keeps). */
+	PCGEXCOLLECTIONS_API bool IsBuiltinHandlerClass(const UClass* HandlerClass);
+}
+#endif

--- a/Source/PCGExCollections/Public/Helpers/PCGExLevelExportHandler.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExLevelExportHandler.h
@@ -1,0 +1,298 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PCGExCollectionsCommon.h"
+#include "StructUtils/InstancedStruct.h"
+#include "Templates/SubclassOf.h"
+#include "UObject/Object.h"
+
+#include "PCGExLevelExportHandler.generated.h"
+
+class AActor;
+class UPCGExAssetCollection;
+class UPCGExLevelDataExporter;
+class UPCGMetadata;
+struct FPCGExAssetCollectionEntry;
+struct FPCGExLevelExportSource;
+
+UENUM()
+enum class EPCGExExportSlotScope : uint8
+{
+	/** One collection per host, compacted across every PCGDataAsset entry (meshes, levels, sketches). */
+	Shared = 0,
+	/** One collection per PCGDataAsset entry, rebuilt from that entry's export alone (actors). */
+	PerEntry = 1,
+};
+
+namespace PCGExLevelExport::Slots
+{
+	// Built-in slot ids double as the exported pin names and the external-asset suffixes.
+	const FName Meshes = PCGExCollections::Labels::MeshesPin;
+	const FName Actors = PCGExCollections::Labels::ActorsPin;
+	const FName Levels = PCGExCollections::Labels::LevelsPin;
+}
+
+/** What a handler contributes: the pin its points land on and the collection its entries live in. */
+struct PCGEXCOLLECTIONS_API FPCGExExportSlotDesc
+{
+	/** Storage key on entries/state and external-asset suffix (<GUID>_<SlotId>). Stable forever. */
+	FName SlotId = NAME_None;
+
+	/** Pin on the exported PCGDataAsset. */
+	FName PinName = NAME_None;
+
+	/** A UPCGExAssetCollection subclass (checked at registration; a plain pointer keeps this header light). */
+	UClass* CollectionClass = nullptr;
+	UScriptStruct* EntryStruct = nullptr;
+	EPCGExExportSlotScope Scope = EPCGExExportSlotScope::Shared;
+
+	/** Local picks carry a secondary index (mesh material variants). */
+	bool bSupportsSecondary = false;
+
+	bool IsValid() const
+	{
+		return !SlotId.IsNone() && !PinName.IsNone() && CollectionClass && EntryStruct;
+	}
+};
+
+#if WITH_EDITOR
+
+/**
+ * Compaction identity for a slot's entries. Hash/Equals decide which contributions merge into one
+ * shared entry; SortKey orders the merged result (process-stable, fully discriminating -- see
+ * PCGExCollectionSortKeys.h); PrimaryPath is the loose key that lets an EntryId survive a content
+ * tweak. Entries are guaranteed to be the slot's EntryStruct.
+ */
+class PCGEXCOLLECTIONS_API IPCGExExportSlotPolicy
+{
+public:
+	virtual ~IPCGExExportSlotPolicy() = default;
+
+	virtual uint32 Hash(const FPCGExAssetCollectionEntry& Entry) const = 0;
+	virtual bool Equals(const FPCGExAssetCollectionEntry& A, const FPCGExAssetCollectionEntry& B) const = 0;
+	virtual FString SortKey(const FPCGExAssetCollectionEntry& Entry) const = 0;
+	virtual FSoftObjectPath PrimaryPath(const FPCGExAssetCollectionEntry& Entry) const = 0;
+};
+
+/** One exported point. Transform is already in the export frame; bounds are point-local. */
+struct PCGEXCOLLECTIONS_API FPCGExExportItem
+{
+	FTransform Transform = FTransform::Identity;
+	FVector BoundsMin = FVector::ZeroVector;
+	FVector BoundsMax = FVector::ZeroVector;
+
+	/** Actor the point was harvested from -- generic per-point attributes (ActorName, value tags) read it. */
+	AActor* SourceActor = nullptr;
+
+	/** Index into the writer's entries; -1 = point without a pick. */
+	int32 LocalEntryIndex = -1;
+
+	/** Secondary pick (material variant); -1 = none. Ignored unless the slot supports secondaries. */
+	int16 SecondaryIndex = -1;
+};
+
+/**
+ * One actor offered to the harvest pass. The root of a subtree export is never an entry itself; every
+ * other candidate carries the slot that claimed it (a handler's Claim, else the exporter's built-in
+ * classification), or None when nothing did.
+ */
+struct PCGEXCOLLECTIONS_API FPCGExExportCandidate
+{
+	AActor* Actor = nullptr;
+	bool bIsRoot = false;
+	FName ClaimedSlot = NAME_None;
+};
+
+/** Per-export handler scratch; the handler defines the concrete type, the writer owns the instance. */
+struct PCGEXCOLLECTIONS_API FPCGExExportScratch
+{
+	virtual ~FPCGExExportScratch() = default;
+};
+
+/**
+ * Per-export, per-slot accumulation a handler writes into: identity-deduplicated entries plus the
+ * points that pick them. The exporter turns it into point data on the slot's pin and either a capture
+ * (Shared) or an embedded collection (PerEntry).
+ */
+class PCGEXCOLLECTIONS_API FPCGExExportSlotWriter
+{
+public:
+	explicit FPCGExExportSlotWriter(const FPCGExExportSlotDesc& InDesc);
+
+	const FPCGExExportSlotDesc Desc;
+
+	/** Entries of Desc.EntryStruct, in local-index order. Weight = number of items that picked them. */
+	TArray<FInstancedStruct> Entries;
+	TArray<FPCGExExportItem> Items;
+
+	/** Optional per-property inherited-defaults view (see FPCGExExportSlotCapture::InheritedDefaults). */
+	TArray<FInstancedStruct> InheritedDefaults;
+
+	/**
+	 * Local index of the entry matching IdentityHash + Equals, adding one (Init runs on a fresh
+	 * Desc.EntryStruct, whose local index is Entries.Num() at that moment) when none does. Weight is
+	 * bumped by WeightIncrement either way. Equals receives the candidate's local index so a handler
+	 * can compare against identity data it keeps parallel to Entries in its scratch.
+	 */
+	int32 FindOrAddEntry(
+		uint32 IdentityHash,
+		TFunctionRef<bool(int32 LocalIndex, const FPCGExAssetCollectionEntry&)> Equals,
+		TFunctionRef<void(FPCGExAssetCollectionEntry&)> Init,
+		int32 WeightIncrement = 1);
+
+	FPCGExAssetCollectionEntry& GetEntry(int32 LocalIndex);
+	const FPCGExAssetCollectionEntry& GetEntry(int32 LocalIndex) const;
+
+	template <typename T>
+	T& GetEntry(const int32 LocalIndex)
+	{
+		return *Entries[LocalIndex].GetMutablePtr<T>();
+	}
+
+	template <typename T>
+	const T& GetEntry(const int32 LocalIndex) const
+	{
+		return *Entries[LocalIndex].GetPtr<T>();
+	}
+
+	FPCGExExportItem& AddItem(const FTransform& InTransform, const FVector& InBoundsMin, const FVector& InBoundsMax, AActor* InSourceActor, int32 InLocalEntryIndex, int16 InSecondaryIndex = -1);
+
+	template <typename T>
+	T& GetOrCreateScratch()
+	{
+		if (!Scratch)
+		{
+			Scratch = MakeShared<T>();
+		}
+		return static_cast<T&>(*Scratch);
+	}
+
+	/** The scratch Collect created, or null when it never did. */
+	template <typename T>
+	const T* GetScratch() const
+	{
+		return static_cast<const T*>(Scratch.Get());
+	}
+
+	bool IsEmpty() const
+	{
+		return Items.IsEmpty();
+	}
+
+private:
+	TMap<uint32, TArray<int32>> Buckets;
+	TSharedPtr<FPCGExExportScratch> Scratch;
+};
+
+#endif // WITH_EDITOR
+
+/**
+ * One kind of level-export content: what claims an actor, what is harvested from it, which pin the
+ * points go to, and which collection type the entries belong to. Registered by CLASS from a module's
+ * StartupModule (PCGExLevelExport::FHandlerRegistry) and run as the class default object -- handlers
+ * are stateless, const-only policies; per-export state lives in the writer's scratch.
+ *
+ * Harvest order per export (UPCGExDefaultLevelDataExporter):
+ *   1. Claim pass: handlers by priority may claim a filtered actor; unclaimed actors fall to the
+ *      exporter's built-in classification (Mesh / Actor / Level).
+ *   2. Harvest pass: every handler sees every candidate (the subtree root included, flagged) with
+ *      its claimed slot, and appends items to its own writer.
+ *   3. Per slot: points emitted on PinName, entries handed off -- captured for shared compaction, or
+ *      built into a per-entry embedded collection.
+ * A handler must only parse candidates that will not be spawned as actors: the root, its own claims,
+ * and content-bearing claims of other slots (meshes). Actor-claimed candidates travel as a class +
+ * delta and already carry their components.
+ */
+UCLASS(Abstract)
+class PCGEXCOLLECTIONS_API UPCGExLevelExportHandler : public UObject
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FPCGExExportSlotDesc GetSlotDesc() const PURE_VIRTUAL(UPCGExLevelExportHandler::GetSlotDesc, return FPCGExExportSlotDesc(););
+	virtual TSharedPtr<const IPCGExExportSlotPolicy> MakePolicy() const PURE_VIRTUAL(UPCGExLevelExportHandler::MakePolicy, return nullptr;);
+
+	/** Lower runs first -- claim order and pin emission order. Built-ins use 10/20/30. */
+	virtual int32 GetPriority() const
+	{
+		return 100;
+	}
+
+	/** Take Actor out of the built-in classification. Return true to make it this slot's candidate. */
+	virtual bool Claim(AActor* Actor, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter) const
+	{
+		return false;
+	}
+
+	virtual void Collect(const FPCGExExportCandidate& Candidate, const FPCGExLevelExportSource& Source, const UPCGExLevelDataExporter* Exporter, FPCGExExportSlotWriter& Writer) const PURE_VIRTUAL(UPCGExLevelExportHandler::Collect,);
+
+	/** Last touch on the writer before points are emitted and entries handed off. */
+	virtual void FinalizeSlot(FPCGExExportSlotWriter& Writer, UObject* Outer, const UPCGExLevelDataExporter* Exporter) const
+	{
+	}
+
+	/** Per-point attributes beyond the generic ActorName / value tags. MetaEntries is parallel to Writer.Items. */
+	virtual void WriteItemAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+	{
+	}
+
+	/** No picks are written when collections are not generated; write whatever has a raw form (asset paths). */
+	virtual void WriteRawAttributes(UPCGMetadata* Meta, TConstArrayView<int64> MetaEntries, const FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+	{
+	}
+
+	/** PerEntry slots only: the embedded collection holds the writer's entries with their EntryIds
+	 *  claimed; runs before its staging rebuild. */
+	virtual void FinalizeEmbeddedCollection(UPCGExAssetCollection* Collection, FPCGExExportSlotWriter& Writer, const UPCGExLevelDataExporter* Exporter) const
+	{
+	}
+#endif
+};
+
+#if WITH_EDITOR
+
+namespace PCGExLevelExport
+{
+	struct PCGEXCOLLECTIONS_API FHandlerRegistration
+	{
+		FPCGExExportSlotDesc Desc;
+		TSharedPtr<const IPCGExExportSlotPolicy> Policy;
+		TSubclassOf<UPCGExLevelExportHandler> HandlerClass;
+		int32 Priority = 100;
+	};
+
+	/**
+	 * Handler classes keyed by slot id. Register from StartupModule only -- never from a static
+	 * initializer: the handler CDO is read at registration (slot descriptor, policy), and a class
+	 * default object cannot be resolved during static init. A module that registers MUST unregister
+	 * from its ShutdownModule: the registry outlives it and holds a policy compiled into its DLL.
+	 */
+	class PCGEXCOLLECTIONS_API FHandlerRegistry
+	{
+	public:
+		static FHandlerRegistry& Get();
+
+		/** Registers HandlerClass under its CDO's slot id. A second class on the same slot is refused. */
+		bool Register(TSubclassOf<UPCGExLevelExportHandler> HandlerClass);
+		void Unregister(FName SlotId);
+
+		bool FindSlot(FName SlotId, FPCGExExportSlotDesc& OutDesc) const;
+		TSharedPtr<const IPCGExExportSlotPolicy> GetPolicy(FName SlotId) const;
+
+		/** Every registration, priority ascending. Copies out; safe to hold. */
+		void GetRegistrations(TArray<FHandlerRegistration>& OutRegistrations) const;
+		void GetSlots(TArray<FPCGExExportSlotDesc>& OutSlots) const;
+
+	private:
+		FHandlerRegistry() = default;
+
+		mutable FRWLock Lock;
+		TMap<FName, FHandlerRegistration> Registrations;
+	};
+}
+
+#endif // WITH_EDITOR


### PR DESCRIPTION
Introduce a keyed export-slot system and pluggable level-export handlers.

- Adds FPCGExExportSlotCapture / FPCGExExportCollectionSlot and PCGExExportSlots utilities; refactors PCGExPCGDataAssetCollection to use SharedSlots / EmbeddedSlots instead of fixed mesh/level/actor members; generalizes compaction, externalization and save-scrub flows to operate per-slot.
- Implements handler registry, writer API, and built-in Mesh/Actor/Level handlers, and updates UPCGExDefaultLevelDataExporter to emit captures/writers.
- Adds helper functions to retire/reparent instanced subobjects and PostLoad migration for deprecated fixed members to keyed slots.
- Registers builtin handlers on module startup/shutdown. Backward-compatible migration & externalization naming preserved.