### PR TITLE
[Collections] Add roaming Omni collections and attribute mapping

### DIFF
--- a/Source/PCGExCollections/Private/Collections/PCGExActorCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExActorCollection.cpp
@@ -57,6 +57,15 @@ bool FPCGExActorCollectionEntry::Validate(const UPCGExAssetCollection* ParentCol
 // then immediately destroys it. Only works in editor context (non-editor falls back to empty bounds).
 void FPCGExActorCollectionEntry::UpdateStaging(const UPCGExAssetCollection* OwningCollection, int32 InInternalIndex, bool bRecursive)
 {
+	// Authored staging (e.g. a runtime-built collection carrying default bounds): recomputing would
+	// force-load the class and clobber the authored content. Refresh identity fields only.
+	if (Staging.bAuthored && !bIsSubCollection)
+	{
+		Staging.Path = Actor.ToSoftObjectPath();
+		FPCGExAssetCollectionEntry::UpdateStaging(OwningCollection, InInternalIndex, bRecursive);
+		return;
+	}
+
 	ClearManagedSockets();
 
 	if (bIsSubCollection)

--- a/Source/PCGExCollections/Private/Collections/PCGExGenericCollectionEntry.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExGenericCollectionEntry.cpp
@@ -3,9 +3,7 @@
 
 #include "Collections/PCGExGenericCollectionEntry.h"
 
-#if WITH_EDITOR
 #include "AssetRegistry/AssetData.h"
-#endif
 
 // Registered by hand (not via PCGEX_REGISTER_COLLECTION_TYPE): there is no typed collection, so
 // CollectionClass stays null. Static-init registration is safe inside PCGExCollections (the module
@@ -31,14 +29,13 @@ namespace PCGExGenericCollectionEntry
 				FTypeRegistry::Get().Register(Info);
 			});
 
-#if WITH_EDITOR
-			// Catch-all for Omni drops: every real detector must sit below this priority.
+			// Catch-all for Omni drops and attribute-set builds: every real detector must sit below
+			// this priority.
 			FTypeRegistry::AddPendingCustomization(TypeIds::Generic, [](FTypeInfo& Info)
 			{
 				Info.SourceDetectPriority = 1000;
 				Info.DetectSourceAsset = [](const FAssetData&) { return true; };
 			});
-#endif
 		}
 	};
 

--- a/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
@@ -11,21 +11,67 @@
 #include "Collections/PCGExSkinnedMeshCollection.h"
 #include "Core/PCGExCollectionHelpers.h"
 
-#if WITH_EDITOR
 #include "AssetRegistry/AssetData.h"
 #include "PCGDataAsset.h"
 #include "UObject/UnrealType.h"
+#include "Blueprint/BlueprintSupport.h"
 #include "Engine/Blueprint.h"
 #include "Engine/SkinnedAsset.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
-#endif
+#include "Misc/PackageName.h"
 
 // Registered manually (not via PCGEX_REGISTER_COLLECTION_TYPE): Omni has no single entry
 // struct, so EntryStruct stays null -- resolve structs per entry via Entry->GetTypeId().
 namespace PCGExOmniCollection
 {
+	/**
+	 * The actor CLASS path an asset stands for, empty when it isn't an actor source. Registry tags
+	 * first: NativeParentClassPath names a native class, always loaded, so the AActor check costs no
+	 * load (cooked registries carry the tags too). A loaded class object (class-path inputs) answers
+	 * directly. The GetAsset() inspection is the editor-only fallback for tagless rows.
+	 */
+	FSoftObjectPath ResolveActorClassPath(const FAssetData& Asset)
+	{
+		if (Asset.IsInstanceOf<UClass>())
+		{
+			// In-memory resolve, not GetAsset(): class rows only come from already-loaded objects, and
+			// GetAsset() routes through a package find-or-load instead of the object path.
+			const UClass* Class = Cast<UClass>(Asset.GetSoftObjectPath().ResolveObject());
+			return Class && Class->IsChildOf(AActor::StaticClass()) ? FSoftObjectPath(Class) : FSoftObjectPath();
+		}
+
+		// IsInstanceOf so UBlueprint subclass assets are claimed too.
+		if (!Asset.IsInstanceOf<UBlueprint>())
+		{
+			return FSoftObjectPath();
+		}
+
+		FString NativeParent;
+		FString GeneratedClass;
+		if (Asset.GetTagValue(FBlueprintTags::NativeParentClassPath, NativeParent) && Asset.GetTagValue(FBlueprintTags::GeneratedClassPath, GeneratedClass))
+		{
+			const FString ParentPath(FPackageName::ExportTextPathToObjectPath(FStringView(NativeParent)));
+			if (const UClass* ParentClass = FindObject<UClass>(nullptr, *ParentPath))
+			{
+				return ParentClass->IsChildOf(AActor::StaticClass())
+					? FSoftObjectPath(FString(FPackageName::ExportTextPathToObjectPath(FStringView(GeneratedClass))))
+					: FSoftObjectPath();
+			}
+		}
+
+#if WITH_EDITOR
+		const UBlueprint* Blueprint = Cast<UBlueprint>(Asset.GetAsset());
+		if (Blueprint && Blueprint->GeneratedClass && Blueprint->GeneratedClass->IsChildOf(AActor::StaticClass()))
+		{
+			return FSoftObjectPath(Blueprint->GeneratedClass.Get());
+		}
+#endif
+
+		return FSoftObjectPath();
+	}
+
 	struct FTypeRegistration
 	{
 		FTypeRegistration()
@@ -56,9 +102,8 @@ namespace PCGExOmniCollection
 				FTypeRegistry::AddPendingCustomization(TypeIds::Level, [](FTypeInfo& Info) { Info.GlobalsStruct = FPCGExLevelCollectionGlobals::StaticStruct(); });
 			}
 
-#if WITH_EDITOR
-			// Source-asset detection for the built-in types (Omni drag-drop ingestion).
-			// Pending customizations run after ALL registrations -- order-safe.
+			// Source-asset detection for the built-in types (Omni drag-drop ingestion and
+			// attribute-set builds). Pending customizations run after ALL registrations -- order-safe.
 			using FTypeRegistry = PCGExAssetCollection::FTypeRegistry;
 			using FTypeInfo = PCGExAssetCollection::FTypeInfo;
 			namespace TypeIds = PCGExAssetCollection::TypeIds;
@@ -78,27 +123,18 @@ namespace PCGExOmniCollection
 			FTypeRegistry::AddPendingCustomization(TypeIds::Actor, [](FTypeInfo& Info)
 			{
 				Info.SourceDetectPriority = 20;
-				// Loads the asset to inspect GeneratedClass -- acceptable for a user-driven drop.
-				Info.DetectSourceAsset = [](const FAssetData& Asset)
-				{
-					// IsInstanceOf so UBlueprint subclass assets are claimed too.
-					if (!Asset.IsInstanceOf<UBlueprint>())
-					{
-						return false;
-					}
-					const UBlueprint* Blueprint = Cast<UBlueprint>(Asset.GetAsset());
-					return Blueprint && Blueprint->GeneratedClass && Blueprint->GeneratedClass->IsChildOf(AActor::StaticClass());
-				};
+				Info.bRuntimeStageable = false; // temp-actor spawn is editor-only
+				Info.DetectSourceAsset = [](const FAssetData& Asset) { return ResolveActorClassPath(Asset).IsValid(); };
 				// The row must reference the GENERATED CLASS, not the blueprint asset.
 				Info.MakeEntryFromSourceAsset = [](const FAssetData& Asset, FInstancedStruct& OutPayload)
 				{
-					const UBlueprint* Blueprint = Cast<UBlueprint>(Asset.GetAsset());
-					if (!Blueprint || !Blueprint->GeneratedClass || !Blueprint->GeneratedClass->IsChildOf(AActor::StaticClass()))
+					const FSoftObjectPath ClassPath = ResolveActorClassPath(Asset);
+					if (!ClassPath.IsValid())
 					{
 						return false;
 					}
 					OutPayload.InitializeAs(FPCGExActorCollectionEntry::StaticStruct());
-					OutPayload.GetMutablePtr<FPCGExAssetCollectionEntry>()->SetAssetPath(FSoftObjectPath(Blueprint->GeneratedClass.Get()));
+					OutPayload.GetMutablePtr<FPCGExAssetCollectionEntry>()->SetAssetPath(ClassPath);
 					return true;
 				};
 			});
@@ -107,6 +143,7 @@ namespace PCGExOmniCollection
 			FTypeRegistry::AddPendingCustomization(TypeIds::Level, [](FTypeInfo& Info)
 			{
 				Info.SourceDetectPriority = 30;
+				Info.bRuntimeStageable = false; // level actor walk is editor-only
 				Info.DetectSourceAsset = [](const FAssetData& Asset) { return Asset.AssetClassPath == UWorld::StaticClass()->GetClassPathName(); };
 			});
 
@@ -124,7 +161,6 @@ namespace PCGExOmniCollection
 					return true;
 				};
 			});
-#endif
 		}
 	};
 
@@ -1022,20 +1058,7 @@ void UPCGExOmniCollection::EDITOR_AddBrowserSelectionInternal(const TArray<FAsse
 {
 	UPCGExAssetCollection::EDITOR_AddBrowserSelectionInternal(InAssetData);
 
-	// Detectors by ascending priority -- copied OUT of the registry: interior pointers must
-	// never outlive the lock (registrations can relocate storage; see FTypeRegistry).
-	TArray<PCGExAssetCollection::FTypeInfo> Detectors;
-	PCGExAssetCollection::FTypeRegistry::Get().ForEach([&Detectors](const PCGExAssetCollection::FTypeInfo& Info)
-	{
-		if (Info.DetectSourceAsset && Info.EntryStruct)
-		{
-			Detectors.Add(Info);
-		}
-	});
-	Detectors.Sort([](const PCGExAssetCollection::FTypeInfo& A, const PCGExAssetCollection::FTypeInfo& B)
-	{
-		return A.SourceDetectPriority < B.SourceDetectPriority;
-	});
+	const PCGExCollectionHelpers::FSourceAssetResolver Resolver;
 
 	// Existing (type, path) pairs so the same asset isn't added twice as the same entry type.
 	auto MakeKey = [](const PCGExAssetCollection::FTypeId TypeId, const FSoftObjectPath& Path)
@@ -1067,45 +1090,21 @@ void UPCGExOmniCollection::EDITOR_AddBrowserSelectionInternal(const TArray<FAsse
 
 	for (const FAssetData& Asset : InAssetData)
 	{
-		for (const PCGExAssetCollection::FTypeInfo& Info : Detectors)
+		FInstancedStruct Payload;
+		if (!Resolver.Resolve(Asset, Payload))
 		{
-			if (!Info.DetectSourceAsset(Asset))
-			{
-				continue;
-			}
-
-			FInstancedStruct Payload;
-			if (Info.MakeEntryFromSourceAsset)
-			{
-				// Factory rejected on closer inspection: fall through to lower-priority detectors.
-				if (!Info.MakeEntryFromSourceAsset(Asset, Payload))
-				{
-					continue;
-				}
-			}
-			else
-			{
-				Payload.InitializeAs(Info.EntryStruct);
-				Payload.GetMutablePtr<FPCGExAssetCollectionEntry>()->SetAssetPath(Asset.ToSoftObjectPath());
-			}
-
-			const FPCGExAssetCollectionEntry* NewEntry = Payload.GetPtr<FPCGExAssetCollectionEntry>();
-			if (!NewEntry)
-			{
-				continue;
-			}
-
-			const uint64 Key = MakeKey(NewEntry->GetTypeId(), NewEntry->Staging.Path);
-			if (ExistingKeys.Contains(Key))
-			{
-				break;
-			}
-
-			ExistingKeys.Add(Key);
-			FPCGExOmniCollectionEntry& Row = Entries.Emplace_GetRef();
-			Row.Entry = MoveTemp(Payload);
-			break; // Asset claimed by this type.
+			continue;
 		}
+
+		const FPCGExAssetCollectionEntry* NewEntry = Payload.GetPtr<FPCGExAssetCollectionEntry>();
+		const uint64 Key = MakeKey(NewEntry->GetTypeId(), NewEntry->Staging.Path);
+		if (ExistingKeys.Contains(Key))
+		{
+			continue;
+		}
+
+		ExistingKeys.Add(Key);
+		Entries.Emplace_GetRef().Entry = MoveTemp(Payload);
 	}
 
 	// Newly ingested entry types arrive with their per-type setup (globals block + machinery

--- a/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
@@ -2859,6 +2859,12 @@ const UScriptStruct* UPCGExAssetCollection::EDITOR_GetEntryScriptStruct(int32 Ra
 
 FPCGExAssetCollectionEntry* UPCGExAssetCollection::EDITOR_AddEntry(const UScriptStruct* EntryStruct)
 {
+	return AddEntryOfType(EntryStruct);
+}
+#endif
+
+FPCGExAssetCollectionEntry* UPCGExAssetCollection::AddEntryOfType(const UScriptStruct* EntryStruct)
+{
 	FArrayProperty* ArrayProp = CastField<FArrayProperty>(GetClass()->FindPropertyByName(FName("Entries")));
 	const FStructProperty* InnerProp = ArrayProp ? CastField<FStructProperty>(ArrayProp->Inner) : nullptr;
 
@@ -2879,4 +2885,3 @@ FPCGExAssetCollectionEntry* UPCGExAssetCollection::EDITOR_AddEntry(const UScript
 	const int32 NewIndex = ArrayHelper.AddValue();
 	return reinterpret_cast<FPCGExAssetCollectionEntry*>(ArrayHelper.GetRawPtr(NewIndex));
 }
-#endif

--- a/Source/PCGExCollections/Private/Core/PCGExCollectionHelpers.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExCollectionHelpers.cpp
@@ -4,19 +4,209 @@
 #include "Core/PCGExCollectionHelpers.h"
 
 #include "PCGParamData.h"
+#include "PCGExProperty.h"
+#include "AssetRegistry/AssetData.h"
+#include "AssetRegistry/IAssetRegistry.h"
 #include "Core/PCGExAssetCollection.h"
 #include "Data/PCGExAttributeBroadcaster.h"
 #include "Details/PCGExStagingDetails.h"
+#include "Helpers/PCGExMetaHelpersMacros.h"
+#include "Helpers/PCGExStreamingHelpers.h"
+#include "Metadata/PCGMetadataAttributeTpl.h"
 #include "UObject/Package.h"
 #include "UObject/UnrealType.h"
 
+namespace PCGExAttributeSetBuild
+{
+	struct FPropertyColumn
+	{
+		const FPCGMetadataAttributeBase* Attribute = nullptr;
+		EPCGMetadataTypes Type = EPCGMetadataTypes::Unknown;
+		int32 SchemaIndex = INDEX_NONE; // position in the built schema (== override slot index)
+	};
+
+	/**
+	 * Declare one schema entry per mapped attribute on the host, then resolve each column's slot index
+	 * from the built schema. Schema is built BEFORE any row exists: per-entry values are written by
+	 * parallel index afterwards, never re-derived from rows (the runtime SyncToSchema resets entries
+	 * to schema defaults).
+	 */
+	void CollectPropertyColumns(
+		UPCGExAssetCollection* InCollection, FPCGExContext* InContext, const UPCGMetadata* Metadata,
+		const FPCGExRoamingAssetCollectionDetails& Details, TArray<FPropertyColumn>& OutColumns, TArray<FInstancedStruct>& OutSchema)
+	{
+		FPCGExAttributeGatherDetails Filter = Details.PropertyAttributes;
+		Filter.Init();
+
+		TArray<FName> Names;
+		TArray<EPCGMetadataTypes> Types;
+		Metadata->GetAttributes(Names, Types);
+
+		TArray<FName> ColumnNames;
+		for (int32 i = 0; i < Names.Num(); i++)
+		{
+			const FName Name = Names[i];
+			if (Name == Details.AssetPathSourceAttribute || Name == Details.WeightSourceAttribute || Name == Details.CategorySourceAttribute)
+			{
+				continue;
+			}
+
+			if (!Filter.Test(Name.ToString()))
+			{
+				continue;
+			}
+
+			FInstancedStruct Property;
+			if (!PCGExProperties::MakePropertyForMetadataType(Types[i], Name, Property))
+			{
+				PCGE_LOG_C(Warning, GraphAndLog, InContext, FText::Format(FTEXT("Attribute '{0}' has no custom property counterpart and was skipped."), FText::FromName(Name)));
+				continue;
+			}
+
+			FPCGExPropertySchema& Schema = InCollection->CollectionProperties.Schemas.Emplace_GetRef();
+			Schema.Name = Name;
+			Schema.Property = MoveTemp(Property);
+			Schema.SyncPropertyName();
+
+			FPropertyColumn& Column = OutColumns.Emplace_GetRef();
+			Column.Attribute = Metadata->GetConstAttribute(Name);
+			Column.Type = Types[i];
+			ColumnNames.Add(Name);
+		}
+
+		if (OutColumns.IsEmpty())
+		{
+			return;
+		}
+
+		TArray<FPCGExHeaderIdRemap> Remaps;
+		InCollection->CollectionProperties.SyncAllSchemas(Remaps);
+		OutSchema = InCollection->CollectionProperties.BuildSchema();
+
+		// Slot index by name rather than insertion order: BuildSchema is the authority on layout.
+		for (int32 c = 0; c < OutColumns.Num(); c++)
+		{
+			OutColumns[c].SchemaIndex = OutSchema.IndexOfByPredicate([&ColumnNames, c](const FInstancedStruct& Slot)
+			{
+				const FPCGExProperty* Prop = Slot.GetPtr<FPCGExProperty>();
+				return Prop && Prop->PropertyName == ColumnNames[c];
+			});
+		}
+	}
+
+	/** Row value -> override slot, converted through the property's TryReadValue. */
+	bool WriteColumn(const FPropertyColumn& Column, const int64 ItemKey, FPCGExProperty* Prop)
+	{
+		switch (Column.Type)
+		{
+#define PCGEX_WRITE_COLUMN(_TYPE, _NAME, ...) \
+		case EPCGMetadataTypes::_NAME: \
+			return Prop->TrySetValue<_TYPE>(static_cast<const FPCGMetadataAttribute<_TYPE>*>(Column.Attribute)->GetValueFromItemKey(ItemKey));
+		PCGEX_FOREACH_SUPPORTEDTYPES(PCGEX_WRITE_COLUMN)
+#undef PCGEX_WRITE_COLUMN
+		default:
+			return false;
+		}
+	}
+}
+
 namespace PCGExCollectionHelpers
 {
+#pragma region FSourceAssetResolver
+
+	FSourceAssetResolver::FSourceAssetResolver()
+	{
+		PCGExAssetCollection::FTypeRegistry::Get().ForEach([this](const PCGExAssetCollection::FTypeInfo& Info)
+		{
+			if (Info.DetectSourceAsset && Info.EntryStruct)
+			{
+				Detectors.Add(Info);
+			}
+		});
+
+		Detectors.Sort([](const PCGExAssetCollection::FTypeInfo& A, const PCGExAssetCollection::FTypeInfo& B)
+		{
+			return A.SourceDetectPriority < B.SourceDetectPriority;
+		});
+	}
+
+	FSourceAssetResolver::~FSourceAssetResolver()
+	{
+		PCGExHelpers::SafeReleaseHandles(Handles);
+	}
+
+	bool FSourceAssetResolver::Resolve(const FAssetData& InAsset, FInstancedStruct& OutPayload) const
+	{
+		for (const PCGExAssetCollection::FTypeInfo& Info : Detectors)
+		{
+			if (!Info.DetectSourceAsset(InAsset))
+			{
+				continue;
+			}
+
+			FInstancedStruct Payload;
+			if (Info.MakeEntryFromSourceAsset)
+			{
+				// Factory rejected on closer inspection: fall through to lower-priority detectors.
+				if (!Info.MakeEntryFromSourceAsset(InAsset, Payload))
+				{
+					continue;
+				}
+			}
+			else
+			{
+				Payload.InitializeAs(Info.EntryStruct);
+				Payload.GetMutablePtr<FPCGExAssetCollectionEntry>()->SetAssetPath(InAsset.ToSoftObjectPath());
+			}
+
+			if (!Payload.GetPtr<FPCGExAssetCollectionEntry>())
+			{
+				continue;
+			}
+
+			OutPayload = MoveTemp(Payload);
+			return true;
+		}
+
+		return false;
+	}
+
+	bool FSourceAssetResolver::ResolvePath(const FSoftObjectPath& InPath, FInstancedStruct& OutPayload, FPCGExContext* InContext)
+	{
+		if (!InPath.IsValid())
+		{
+			return false;
+		}
+
+		FAssetData Asset;
+		if (const IAssetRegistry* Registry = IAssetRegistry::Get())
+		{
+			Asset = Registry->GetAssetByObjectPath(InPath);
+		}
+
+		if (!Asset.IsValid())
+		{
+			// No registry row (class paths, unscanned assets): resolve through the loaded object. A class
+			// must yield its own row, not its Blueprint's (AllowBlueprintClass).
+			Handles.Add(PCGExHelpers::LoadBlocking_AnyThread(InPath, InContext));
+			const UObject* Object = InPath.ResolveObject();
+			if (!Object)
+			{
+				return false;
+			}
+			Asset = FAssetData(Object, FAssetData::ECreationFlags::AllowBlueprintClass);
+		}
+
+		return Resolve(Asset, OutPayload);
+	}
+
+#pragma endregion
+
 	bool BuildFromAttributeSet(
 		UPCGExAssetCollection* InCollection,
 		FPCGExContext* InContext,
 		const UPCGParamData* InAttributeSet,
-		const FPCGExAssetAttributeSetDetails& Details,
+		const FPCGExRoamingAssetCollectionDetails& Details,
 		bool bBuildStaging)
 	{
 		if (!InCollection || !InAttributeSet)
@@ -37,6 +227,16 @@ namespace PCGExCollectionHelpers
 			return false;
 		}
 
+		const FPCGMetadataAttribute<FSoftObjectPath>* SoftPathAttribute = PathAttribute->GetTypeId() == PCG::Private::MetadataTypes<FSoftObjectPath>::Id
+			? static_cast<const FPCGMetadataAttribute<FSoftObjectPath>*>(PathAttribute) : nullptr;
+		const FPCGMetadataAttribute<FString>* StringPathAttribute = PathAttribute->GetTypeId() == PCG::Private::MetadataTypes<FString>::Id
+			? static_cast<const FPCGMetadataAttribute<FString>*>(PathAttribute) : nullptr;
+		if (!SoftPathAttribute && !StringPathAttribute)
+		{
+			PCGE_LOG_C(Error, GraphAndLog, InContext, FText::Format(FTEXT("Asset path attribute '{0}' must be a Soft Object Path or a String."), FText::FromName(Details.AssetPathSourceAttribute)));
+			return false;
+		}
+
 		const FPCGMetadataAttribute<int32>* WeightAttribute = nullptr;
 		if (Details.WeightSourceAttribute != NAME_None)
 		{
@@ -49,58 +249,59 @@ namespace PCGExCollectionHelpers
 			CategoryAttribute = Metadata->GetConstTypedAttribute<FName>(Details.CategorySourceAttribute);
 		}
 
-		const int32 NumEntries = Metadata->GetLocalItemCount();
-		if (NumEntries == 0)
+		const int32 NumRows = Metadata->GetLocalItemCount();
+		if (NumRows == 0)
 		{
 			return false;
 		}
 
-		InCollection->InitNumEntries(NumEntries);
+		InCollection->DefaultStagingBounds = Details.DefaultStagingBounds;
 
-		// Populate entries
-		int32 ValidEntries = 0;
-		for (int64 ItemKey = 0; ItemKey < NumEntries; ItemKey++)
+		TArray<PCGExAttributeSetBuild::FPropertyColumn> Columns;
+		TArray<FInstancedStruct> Schema;
+		PCGExAttributeSetBuild::CollectPropertyColumns(InCollection, InContext, Metadata, Details, Columns, Schema);
+
+		FSourceAssetResolver Resolver;
+		TSet<const UScriptStruct*> RejectedTypes;
+		int32 NumAppended = 0;
+
+#if !WITH_EDITOR
+		TMap<const UScriptStruct*, bool> StageableByType;
+		int32 NumAuthored = 0;
+#endif
+
+		for (int64 ItemKey = 0; ItemKey < NumRows; ItemKey++)
 		{
-			FSoftObjectPath Path;
-
-			// Extract path based on attribute type
-			if (const FPCGMetadataAttribute<FSoftObjectPath>* SoftPathAttr = static_cast<const FPCGMetadataAttribute<FSoftObjectPath>*>(PathAttribute);
-				SoftPathAttr && PathAttribute->GetTypeId() == PCG::Private::MetadataTypes<FSoftObjectPath>::Id)
-			{
-				Path = SoftPathAttr->GetValueFromItemKey(ItemKey);
-			}
-			else if (const FPCGMetadataAttribute<FString>* StringAttr = static_cast<const FPCGMetadataAttribute<FString>*>(PathAttribute);
-				StringAttr && PathAttribute->GetTypeId() == PCG::Private::MetadataTypes<FString>::Id)
-			{
-				Path = FSoftObjectPath(StringAttr->GetValueFromItemKey(ItemKey));
-			}
-			else
-			{
-				continue; // Skip unsupported attribute types
-			}
-
+			const FSoftObjectPath Path = SoftPathAttribute
+				? SoftPathAttribute->GetValueFromItemKey(ItemKey)
+				: FSoftObjectPath(StringPathAttribute->GetValueFromItemKey(ItemKey));
 			if (!Path.IsValid())
 			{
 				continue;
 			}
 
-			// Get mutable entry via ForEach (a bit awkward but maintains abstraction)
-			FPCGExAssetCollectionEntry* Entry = nullptr;
-			int32 CurrentIndex = ValidEntries;
-			InCollection->ForEachEntry([&](FPCGExAssetCollectionEntry* E, int32 Idx)
+			FInstancedStruct Payload;
+			if (!Resolver.ResolvePath(Path, Payload, InContext))
 			{
-				if (Idx == CurrentIndex)
-				{
-					Entry = E;
-				}
-			});
-
-			if (!Entry)
-			{
+				PCGE_LOG_C(Warning, GraphAndLog, InContext, FText::Format(FTEXT("Asset '{0}' could not be resolved and was skipped."), FText::FromString(Path.ToString())));
 				continue;
 			}
 
-			Entry->SetAssetPath(Path);
+			const UScriptStruct* PayloadStruct = Payload.GetScriptStruct();
+			FPCGExAssetCollectionEntry* Entry = InCollection->AddEntryOfType(PayloadStruct);
+			if (!Entry)
+			{
+				bool bAlreadyRejected = false;
+				RejectedTypes.Add(PayloadStruct, &bAlreadyRejected);
+				if (!bAlreadyRejected)
+				{
+					PCGE_LOG_C(Warning, GraphAndLog, InContext, FText::Format(FTEXT("'{0}' entries are not supported by this collection type; matching rows were skipped."), FText::FromString(PayloadStruct->GetName())));
+				}
+				continue;
+			}
+
+			// The host created the row as its own type; the payload is that type or a base of it.
+			PayloadStruct->CopyScriptStruct(Entry, Payload.GetMemory());
 
 			if (WeightAttribute)
 			{
@@ -112,12 +313,52 @@ namespace PCGExCollectionHelpers
 				Entry->Category = CategoryAttribute->GetValueFromItemKey(ItemKey);
 			}
 
-			ValidEntries++;
+			if (!Columns.IsEmpty())
+			{
+				Entry->PropertyOverrides.SyncToSchema(Schema);
+				for (const PCGExAttributeSetBuild::FPropertyColumn& Column : Columns)
+				{
+					if (!Entry->PropertyOverrides.Overrides.IsValidIndex(Column.SchemaIndex))
+					{
+						continue;
+					}
+					FPCGExPropertyOverrideEntry& Slot = Entry->PropertyOverrides.Overrides[Column.SchemaIndex];
+					FPCGExProperty* Prop = Slot.GetPropertyMutable();
+					Slot.bEnabled = Prop && PCGExAttributeSetBuild::WriteColumn(Column, ItemKey, Prop);
+				}
+			}
+
+#if !WITH_EDITOR
+			// Types whose UpdateStaging can only measure in the editor take the default box instead of
+			// an empty one (after SetAssetPath, which clears bAuthored).
+			bool* bStageable = StageableByType.Find(PayloadStruct);
+			if (!bStageable)
+			{
+				PCGExAssetCollection::FTypeInfo Info;
+				const bool bResolved = PCGExAssetCollection::FTypeRegistry::Get().GetInfoByEntryStruct(PayloadStruct, Info);
+				bStageable = &StageableByType.Add(PayloadStruct, !bResolved || Info.bRuntimeStageable);
+			}
+			if (!*bStageable)
+			{
+				Entry->Staging.Bounds = Details.DefaultStagingBounds;
+				Entry->Staging.bAuthored = true;
+				NumAuthored++;
+			}
+#endif
+
+			NumAppended++;
 		}
 
-		if (ValidEntries < NumEntries)
+#if !WITH_EDITOR
+		if (NumAuthored > 0 && !Details.bQuietRuntimeStagingWarning)
 		{
-			InCollection->InitNumEntries(ValidEntries);
+			PCGE_LOG_C(Warning, GraphAndLog, InContext, FText::Format(FTEXT("{0} entries (actors, levels) cannot be staged outside the editor and use Default Staging Bounds."), NumAuthored));
+		}
+#endif
+
+		if (NumAppended == 0)
+		{
+			return false;
 		}
 
 		if (bBuildStaging)
@@ -125,14 +366,14 @@ namespace PCGExCollectionHelpers
 			InCollection->RebuildStagingData(false);
 		}
 
-		return ValidEntries > 0;
+		return true;
 	}
 
 	bool BuildFromAttributeSet(
 		UPCGExAssetCollection* InCollection,
 		FPCGExContext* InContext,
 		FName InputPin,
-		const FPCGExAssetAttributeSetDetails& Details,
+		const FPCGExRoamingAssetCollectionDetails& Details,
 		bool bBuildStaging)
 	{
 		TArray<FPCGTaggedData> Inputs = InContext->InputData.GetInputsByPin(InputPin);

--- a/Source/PCGExCollections/Private/Details/PCGExRoamingAssetCollectionDetails.cpp
+++ b/Source/PCGExCollections/Private/Details/PCGExRoamingAssetCollectionDetails.cpp
@@ -4,37 +4,43 @@
 
 #include "Details/PCGExRoamingAssetCollectionDetails.h"
 
+#include "Collections/PCGExOmniCollection.h"
 #include "Containers/PCGExManagedObjects.h"
-#include "Core/PCGExAssetCollection.h"
 #include "Core/PCGExCollectionHelpers.h"
 #include "Details/PCGExSettingsDetails.h"
 #include "UObject/Object.h"
 #include "UObject/Package.h"
 
-FPCGExRoamingAssetCollectionDetails::FPCGExRoamingAssetCollectionDetails(const TSubclassOf<UPCGExAssetCollection>& InAssetCollectionType)
-	: bSupportCustomType(false)
-	  , AssetCollectionType(InAssetCollectionType)
-{
-}
-
 bool FPCGExRoamingAssetCollectionDetails::Validate(FPCGExContext* InContext) const
 {
-	if (!AssetCollectionType)
+	if (AssetPathSourceAttribute.IsNone())
 	{
-		PCGE_LOG_C(Error, GraphAndLog, InContext, FTEXT("Collection type is not set."));
+		PCGE_LOG_C(Error, GraphAndLog, InContext, FTEXT("Asset path attribute is not set."));
 		return false;
 	}
 
 	return true;
 }
 
+FString FPCGExRoamingAssetCollectionDetails::GetConfigId() const
+{
+	TStringBuilder<512> Builder;
+	Builder << AssetPathSourceAttribute << TEXT('|') << WeightSourceAttribute << TEXT('|') << CategorySourceAttribute;
+	Builder << TEXT('|') << static_cast<int32>(PropertyAttributes.FilterMode)
+		<< TEXT('|') << PropertyAttributes.CommaSeparatedNames
+		<< TEXT('|') << static_cast<int32>(PropertyAttributes.CommaSeparatedNameFilter)
+		<< TEXT('|') << (PropertyAttributes.bPreservePCGExData ? 1 : 0);
+	for (const TPair<FString, EPCGExStringMatchMode>& Match : PropertyAttributes.Matches)
+	{
+		Builder << TEXT('|') << Match.Key << TEXT(':') << static_cast<int32>(Match.Value);
+	}
+	Builder << TEXT('|') << DefaultStagingBounds.ToString();
+	return Builder.ToString();
+}
+
 UPCGExAssetCollection* FPCGExRoamingAssetCollectionDetails::TryBuildCollection(FPCGExContext* InContext, const UPCGParamData* InAttributeSet, const bool bBuildStaging) const
 {
-	if (!AssetCollectionType)
-	{
-		return nullptr;
-	}
-	UPCGExAssetCollection* Collection = InContext->ManagedObjects->New<UPCGExAssetCollection>(GetTransientPackage(), AssetCollectionType.Get(), NAME_None);
+	UPCGExOmniCollection* Collection = InContext->ManagedObjects->New<UPCGExOmniCollection>(GetTransientPackage());
 	if (!Collection)
 	{
 		return nullptr;
@@ -51,11 +57,7 @@ UPCGExAssetCollection* FPCGExRoamingAssetCollectionDetails::TryBuildCollection(F
 
 UPCGExAssetCollection* FPCGExRoamingAssetCollectionDetails::TryBuildCollection(FPCGExContext* InContext, const FName InputPin, const bool bBuildStaging) const
 {
-	if (!AssetCollectionType)
-	{
-		return nullptr;
-	}
-	UPCGExAssetCollection* Collection = InContext->ManagedObjects->New<UPCGExAssetCollection>(GetTransientPackage(), AssetCollectionType.Get(), NAME_None);
+	UPCGExOmniCollection* Collection = InContext->ManagedObjects->New<UPCGExOmniCollection>(GetTransientPackage());
 	if (!Collection)
 	{
 		return nullptr;

--- a/Source/PCGExCollections/Private/Elements/PCGExBuildAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExBuildAssetCollection.cpp
@@ -11,7 +11,7 @@
 #include "PCGParamData.h"
 #include "PCGPin.h"
 
-#include "Collections/PCGExMeshCollection.h"
+#include "Collections/PCGExOmniCollection.h"
 #include "Containers/PCGExManagedObjects.h"
 #include "Core/PCGExAssetCollection.h"
 #include "Core/PCGExCollectionHelpers.h"
@@ -42,13 +42,6 @@ bool UPCGExManagedAssetCollection::Release(bool bHardRelease, TSet<TSoftObjectPt
 #pragma endregion
 
 #pragma region UPCGExBuildAssetCollectionSettings
-
-UPCGExBuildAssetCollectionSettings::UPCGExBuildAssetCollectionSettings()
-{
-	// Mesh is the sensible default: the common case, and the only type that can rebuild staging outside the
-	// editor. bSupportCustomType stays true, so it's user-changeable.
-	AttributeSetDetails.AssetCollectionType = UPCGExMeshCollection::StaticClass();
-}
 
 TArray<FPCGPinProperties> UPCGExBuildAssetCollectionSettings::InputPinProperties() const
 {
@@ -84,20 +77,6 @@ PCGEX_INITIALIZE_ELEMENT(BuildAssetCollection)
 
 #pragma region FPCGExBuildAssetCollectionElement
 
-namespace PCGExBuildAssetCollection
-{
-	// Config-axis half of the reuse key (folded with the input's data CRC in AdvanceWork).
-	FString BuildConfigId(const FPCGExRoamingAssetCollectionDetails& Details)
-	{
-		return FString::Printf(
-			TEXT("%s|%s|%s|%s"),
-			*GetPathNameSafe(Details.AssetCollectionType.Get()),
-			*Details.AssetPathSourceAttribute.ToString(),
-			*Details.WeightSourceAttribute.ToString(),
-			*Details.CategorySourceAttribute.ToString());
-	}
-}
-
 bool FPCGExBuildAssetCollectionElement::AdvanceWork(FPCGExContext* InContext, const UPCGExSettings* InSettings) const
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FPCGExBuildAssetCollectionElement::Execute);
@@ -131,7 +110,7 @@ bool FPCGExBuildAssetCollectionElement::AdvanceWork(FPCGExContext* InContext, co
 		return Context->TryComplete();
 	};
 
-	// No collection type -> nothing to build.
+	// No asset path attribute -> nothing to build.
 	if (!Settings->AttributeSetDetails.Validate(Context))
 	{
 		return CompleteWith(FSoftObjectPath());
@@ -160,7 +139,7 @@ bool FPCGExBuildAssetCollectionElement::AdvanceWork(FPCGExContext* InContext, co
 
 	// Reuse key = config string + the input's full data CRC. A 32-bit collision only risks reusing a stale
 	// collection until the next input change, never a crash.
-	const FString ConfigId = PCGExBuildAssetCollection::BuildConfigId(Settings->AttributeSetDetails);
+	const FString ConfigId = Settings->AttributeSetDetails.GetConfigId();
 	uint32 Hash = GetTypeHash(ConfigId);
 	if (const FPCGCrc DataCrc = InParam->GetOrComputeCrc(/*bFullDataCrc=*/true); DataCrc.IsValid())
 	{
@@ -182,8 +161,7 @@ bool FPCGExBuildAssetCollectionElement::AdvanceWork(FPCGExContext* InContext, co
 	Managed->SetCrc(Crc);
 	Managed->Config = ConfigId;
 
-	UPCGExAssetCollection* Collection = NewObject<UPCGExAssetCollection>(
-		Managed, Settings->AttributeSetDetails.AssetCollectionType.Get(), NAME_None, RF_Transient);
+	UPCGExOmniCollection* Collection = NewObject<UPCGExOmniCollection>(Managed, NAME_None, RF_Transient);
 
 	// Bake staging now (RebuildStagingData self-loads each asset on the GT) so downstream consumes the
 	// collection exactly like a saved asset.

--- a/Source/PCGExCollections/Private/Elements/PCGExStagingSplineMesh.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExStagingSplineMesh.cpp
@@ -239,7 +239,7 @@ bool FPCGExPathSplineMeshElement::Boot(FPCGExContext* InContext) const
 		}
 		else if (Settings->CollectionSource == EPCGExCollectionSource::AttributeSet)
 		{
-			Context->MainCollection = Cast<UPCGExMeshCollection>(Settings->AttributeSetDetails.TryBuildCollection(Context, PCGExCollections::Labels::SourceAssetCollection, false));
+			Context->MainCollection = Settings->AttributeSetDetails.TryBuildCollection(Context, PCGExCollections::Labels::SourceAssetCollection, false);
 			if (!Context->MainCollection)
 			{
 				PCGE_LOG(Error, GraphAndLog, FTEXT("Failed to build collection from attribute set."));
@@ -296,9 +296,10 @@ void FPCGExPathSplineMeshContext::RegisterAssetDependencies()
 		CollectionsLoader->Finalize();
 
 		TSet<FSoftObjectPath>& Required = GetRequiredAssets();
+		// Any host type: non-Mesh entries are skipped per entry at pick time.
 		for (const TPair<PCGExValueHash, TObjectPtr<UPCGExAssetCollection>>& Pair : CollectionsLoader->AssetsMap)
 		{
-			if (!Pair.Value || Pair.Value->GetTypeId() != PCGExAssetCollection::TypeIds::Mesh)
+			if (!Pair.Value)
 			{
 				continue;
 			}
@@ -352,6 +353,19 @@ bool FPCGExPathSplineMeshElement::PostBoot(FPCGExContext* InContext) const
 		return false;
 	}
 	Context->MainCollection->LoadCache(); // Make sure to load the stuff
+
+	// Any host is accepted but only Mesh entries apply; a host with none would silently spawn nothing.
+	// Subcollection rows count as potential carriers (their contents are resolved at pick time).
+	bool bAnyMeshEntry = false;
+	Context->MainCollection->ForEachEntry([&bAnyMeshEntry](const FPCGExAssetCollectionEntry* Entry, int32)
+	{
+		bAnyMeshEntry |= Entry->bIsSubCollection || Entry->IsType(PCGExAssetCollection::TypeIds::Mesh);
+	});
+	if (!bAnyMeshEntry)
+	{
+		PCGE_LOG(Warning, GraphAndLog, FTEXT("The collection has no Mesh entries; Spline Mesh only applies Mesh entries."));
+	}
+
 	return true;
 }
 

--- a/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
@@ -110,10 +110,10 @@ public:
 
 	/**
 	 * Append a row default-initialized as EntryStruct (any entry-derived struct, base
-	 * included -- what subcollection rows use); null if invalid. Caller owns Modify /
-	 * MarkPackageDirty / staging rebuild.
+	 * included -- what subcollection rows use); null if invalid or null (untyped adds are
+	 * meaningless on a heterogeneous host). Caller owns Modify / MarkPackageDirty / staging rebuild.
 	 */
-	FPCGExAssetCollectionEntry* AddEntryOfType(const UScriptStruct* EntryStruct);
+	virtual FPCGExAssetCollectionEntry* AddEntryOfType(const UScriptStruct* EntryStruct) override;
 
 #if WITH_EDITOR
 	/**

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -922,13 +922,7 @@ public:
 	{
 	}
 
-	/**
-	 * Append one default-initialized entry; null EntryStruct = the native entry type. Base
-	 * accepts the Entries inner struct or a base of it (element is created NATIVE, caller
-	 * copies the requested portion); Omni accepts any entry-derived payload. Null on
-	 * rejection -- doubles as the compatibility arbiter for cross-collection transfers.
-	 * Caller owns transaction/Modify/PostEditChange.
-	 */
+	/** Editor add: AddEntryOfType plus the host's per-type setup (Omni). Caller owns transaction/Modify/PostEditChange. */
 	virtual FPCGExAssetCollectionEntry* EDITOR_AddEntry(const UScriptStruct* EntryStruct = nullptr);
 #endif
 
@@ -971,6 +965,14 @@ public:
 
 	/** Initialize entries array to given size */
 	virtual void InitNumEntries(int32 Num) PCGEX_NOT_IMPLEMENTED(InitNumEntries)
+
+	/**
+	 * Append one default-initialized entry; null EntryStruct = the native entry type. Base accepts the
+	 * Entries inner struct or a base of it (element is created NATIVE, caller copies the requested
+	 * portion); Omni accepts any entry-derived payload. Null on rejection -- doubles as the
+	 * compatibility arbiter for cross-collection transfers. No Modify/dirty/staging: caller owns them.
+	 */
+	virtual FPCGExAssetCollectionEntry* AddEntryOfType(const UScriptStruct* EntryStruct = nullptr);
 
 	/** ForEach iteration (const) */
 	using FForEachConstEntryFunc = TFunctionRef<void(const FPCGExAssetCollectionEntry*, int32)>;

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollectionTypes.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollectionTypes.h
@@ -11,9 +11,7 @@
 
 class UPCGExAssetCollection;
 struct FPCGExAssetCollectionEntry;
-#if WITH_EDITOR
 struct FAssetData;
-#endif
 
 /**
  * Runtime type registry for collection types. Allows the system to discover, query,
@@ -93,10 +91,10 @@ namespace PCGExAssetCollection
 		FText DisplayName;
 		FTypeId ParentType = NAME_None; // For inheritance checking
 
-#if WITH_EDITOR
 		/**
-		 * True when the given content-browser asset can seed an entry of this type (drives
-		 * Omni drop routing). Register via AddPendingCustomization; null = doesn't participate.
+		 * True when the given asset can seed an entry of this type. Runtime seam: drives Omni drop
+		 * routing AND attribute-set builds (PCGExCollectionHelpers::FSourceAssetResolver), so it must
+		 * not load in the common case. Register via AddPendingCustomization; null = doesn't participate.
 		 */
 		TFunction<bool(const FAssetData&)> DetectSourceAsset;
 
@@ -109,7 +107,12 @@ namespace PCGExAssetCollection
 
 		/** Lower values are offered the asset first when several detectors could claim it. */
 		int32 SourceDetectPriority = 100;
-#endif
+
+		/**
+		 * False when the type's UpdateStaging can only measure in editor builds (Actor spawns a temp
+		 * actor, Level walks the world). Runtime builders then author a default box instead.
+		 */
+		bool bRuntimeStageable = true;
 
 		/** A type needs a collection class (typed hosts), an entry struct (entry-only types), or both. */
 		bool IsValid() const

--- a/Source/PCGExCollections/Public/Core/PCGExCollectionHelpers.h
+++ b/Source/PCGExCollections/Public/Core/PCGExCollectionHelpers.h
@@ -7,16 +7,50 @@
 #include "PCGExAssetCollection.h"
 #include "PCGParamData.h"
 #include "Core/PCGExContext.h"
+#include "Details/PCGExRoamingAssetCollectionDetails.h"
 #include "Details/PCGExStagingDetails.h"
+
+struct FAssetData;
+struct FStreamableHandle;
 
 /**
  * Collection Helper Functions
- * 
+ *
  * Simplified API for working with asset collections: convenience functions and attribute set building.
  */
 
 namespace PCGExCollectionHelpers
 {
+	/**
+	 * Registry-driven entry-payload resolution: the highest-priority type whose DetectSourceAsset claims
+	 * an asset builds its payload (MakeEntryFromSourceAsset, else InitializeAs + SetAssetPath). Detectors
+	 * are snapshotted at construction (copied out of the registry -- interior pointers never outlive its
+	 * lock), so build one per operation, not per asset. Shared by Omni drop routing and attribute-set
+	 * builds.
+	 */
+	class PCGEXCOLLECTIONS_API FSourceAssetResolver
+	{
+	public:
+		FSourceAssetResolver();
+		~FSourceAssetResolver();
+		FSourceAssetResolver(const FSourceAssetResolver&) = delete;
+		FSourceAssetResolver& operator=(const FSourceAssetResolver&) = delete;
+
+		/** Payload for a registry row; false when no type claims it (Generic catches every registered asset). */
+		bool Resolve(const FAssetData& InAsset, FInstancedStruct& OutPayload) const;
+
+		/**
+		 * Payload for an object path. Registry row first (no load); paths without one (class paths,
+		 * unscanned assets) load the object and resolve through it. Loads stay pinned for the resolver's
+		 * lifetime.
+		 */
+		bool ResolvePath(const FSoftObjectPath& InPath, FInstancedStruct& OutPayload, FPCGExContext* InContext = nullptr);
+
+	private:
+		TArray<PCGExAssetCollection::FTypeInfo> Detectors;
+		TArray<TSharedPtr<FStreamableHandle>> Handles;
+	};
+
 	/**
 	 * Per-type slot identity: base and derived globals blocks / machinery state classes
 	 * answer the same queries, so they share ONE slot. Both directions on purpose -- see
@@ -35,31 +69,28 @@ namespace PCGExCollectionHelpers
 	}
 
 	/**
-	 * Build a collection from an attribute set
-	 * @param InCollection Target collection to populate
-	 * @param InContext PCG context
-	 * @param InAttributeSet Attribute set containing asset paths
-	 * @param Details Configuration for how to map attributes to entries
-	 * @param bBuildStaging Whether to rebuild staging data after building
-	 * @return true if successful
+	 * Append one entry per attribute-set row to InCollection: entry type from the registry (FSourceAssetResolver,
+	 * unclaimed assets become Generic), row appended through AddEntryOfType (a typed host rejects foreign
+	 * types -- skipped with a warning), extra attributes mapped to custom properties (schema on the
+	 * collection, enabled override per entry). Outside the editor, non-runtime-stageable types (Actor,
+	 * Level) are authored with Details.DefaultStagingBounds. Also copies Details.DefaultStagingBounds onto
+	 * the host. Returns true when at least one entry was appended.
 	 */
 	PCGEXCOLLECTIONS_API
 	bool BuildFromAttributeSet(
 		UPCGExAssetCollection* InCollection,
 		FPCGExContext* InContext,
 		const UPCGParamData* InAttributeSet,
-		const FPCGExAssetAttributeSetDetails& Details,
+		const FPCGExRoamingAssetCollectionDetails& Details,
 		bool bBuildStaging = false);
 
-	/**
-	 * Build a collection from an attribute set on a specific input pin
-	 */
+	/** BuildFromAttributeSet over the first attribute set found on InputPin. */
 	PCGEXCOLLECTIONS_API
 	bool BuildFromAttributeSet(
 		UPCGExAssetCollection* InCollection,
 		FPCGExContext* InContext,
 		FName InputPin,
-		const FPCGExAssetAttributeSetDetails& Details,
+		const FPCGExRoamingAssetCollectionDetails& Details,
 		bool bBuildStaging);
 
 	/**

--- a/Source/PCGExCollections/Public/Details/PCGExRoamingAssetCollectionDetails.h
+++ b/Source/PCGExCollections/Public/Details/PCGExRoamingAssetCollectionDetails.h
@@ -7,11 +7,16 @@
 #include "PCGExCollectionsCommon.h"
 #include "Core/PCGExAssetCollection.h"
 #include "Data/Utils/PCGExDataFilterDetails.h"
+#include "Details/PCGExStagingDetails.h"
 #include "PCGExRoamingAssetCollectionDetails.generated.h"
 
-class UPCGExBitmaskCollection;
 class UPCGParamData;
 
+/**
+ * Builds a transient ("roaming") Omni collection from an attribute set: each row's entry type is
+ * inferred from the type registry (same routing as Omni drag-drop; unclaimed assets become Generic
+ * entries), and extra attributes become custom properties on the collection and its entries.
+ */
 USTRUCT(BlueprintType)
 struct PCGEXCOLLECTIONS_API FPCGExRoamingAssetCollectionDetails : public FPCGExAssetAttributeSetDetails
 {
@@ -19,16 +24,22 @@ struct PCGEXCOLLECTIONS_API FPCGExRoamingAssetCollectionDetails : public FPCGExA
 
 	FPCGExRoamingAssetCollectionDetails() = default;
 
-	explicit FPCGExRoamingAssetCollectionDetails(const TSubclassOf<UPCGExAssetCollection>& InAssetCollectionType);
+	/** Extra attributes exposed as custom properties: one schema entry per attribute, each row's value as an enabled entry override. The path / weight / category attributes are never mapped. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable))
+	FPCGExAttributeGatherDetails PropertyAttributes;
 
-	UPROPERTY()
-	bool bSupportCustomType = true;
+	/** Staged bounds for entries that cannot measure their asset: Generic entries always, actors and levels when built outside the editor. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings)
+	FBox DefaultStagingBounds = FBox(FVector(-50.0), FVector(50.0));
 
-	/** Defines what type of temp collection to build from input attribute set */
-	UPROPERTY(BlueprintReadOnly, EditAnywhere, NoClear, Category = Settings, meta=(PCG_Overridable, EditCondition="bSupportCustomType", EditConditionHides, HideEditConditionToggle))
-	TSubclassOf<UPCGExAssetCollection> AssetCollectionType;
+	/** Suppress the warning emitted outside the editor when actor or level entries fall back to Default Staging Bounds. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, AdvancedDisplay)
+	bool bQuietRuntimeStagingWarning = false;
 
 	bool Validate(FPCGExContext* InContext) const;
+
+	/** Build-config identity: every setting that shapes the built collection, excluding the attribute data itself. */
+	FString GetConfigId() const;
 
 	UPCGExAssetCollection* TryBuildCollection(FPCGExContext* InContext, const UPCGParamData* InAttributeSet, const bool bBuildStaging = false) const;
 	UPCGExAssetCollection* TryBuildCollection(FPCGExContext* InContext, const FName InputPin, const bool bBuildStaging) const;

--- a/Source/PCGExCollections/Public/Elements/PCGExBuildAssetCollection.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExBuildAssetCollection.h
@@ -42,8 +42,9 @@ public:
 };
 
 /**
- * Builds a transient asset collection (with baked staging) from an input attribute set and outputs its soft
+ * Builds a transient Omni collection (with baked staging) from an input attribute set and outputs its soft
  * path, so Staging : Distribute can consume it via SourceCollection (Constant) as if it were a saved asset.
+ * Entry types are inferred per row from the type registry; extra attributes become custom properties.
  * Inverse of Asset Collection to Set. Anchored by a UPCGExManagedAssetCollection on the component, so
  * identical inputs dedup by CRC and survive regeneration. Main-thread-only + non-cacheable (see below).
  */
@@ -53,11 +54,9 @@ class UPCGExBuildAssetCollectionSettings : public UPCGExSettings
 	GENERATED_BODY()
 
 public:
-	UPCGExBuildAssetCollectionSettings();
-
 	//~Begin UPCGSettings
 #if WITH_EDITOR
-	PCGEX_NODE_INFOS(BuildAssetCollection, "Build Asset Collection", "Builds a transient asset collection from an input attribute set and outputs its soft path for a Staging : Distribute SourceCollection (Constant) override.")
+	PCGEX_NODE_INFOS(BuildAssetCollection, "Build Asset Collection", "Builds a transient Omni collection from an input attribute set (entry types inferred per row, extra attributes mapped to custom properties) and outputs its soft path for a Staging : Distribute SourceCollection (Constant) override.")
 
 	virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::Generic; }
 
@@ -77,7 +76,7 @@ protected:
 	virtual FPCGElementPtr CreateElement() const override;
 
 public:
-	/** Which collection type to build, and which attributes hold the asset path / weight / category. */
+	/** Which attributes hold the asset path / weight / category, which extra attributes become custom properties, and the default staging bounds. */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta = (PCG_Overridable))
 	FPCGExRoamingAssetCollectionDetails AttributeSetDetails;
 

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingSplineMesh.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingSplineMesh.h
@@ -99,11 +99,12 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable, EditCondition="!bUseStagedPoints", EditConditionHides))
 	EPCGExCollectionSource CollectionSource = EPCGExCollectionSource::Asset;
 
+	/** Any asset collection host (typed Mesh, Omni, ...); only its Mesh entries ever apply, other entry types are skipped. */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable, EditCondition="!bUseStagedPoints && CollectionSource == EPCGExCollectionSource::Asset", EditConditionHides))
-	TSoftObjectPtr<UPCGExMeshCollection> AssetCollection;
+	TSoftObjectPtr<UPCGExAssetCollection> AssetCollection;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable, EditCondition="!bUseStagedPoints && CollectionSource == EPCGExCollectionSource::AttributeSet", EditConditionHides))
-	FPCGExRoamingAssetCollectionDetails AttributeSetDetails = FPCGExRoamingAssetCollectionDetails(UPCGExMeshCollection::StaticClass());
+	FPCGExRoamingAssetCollectionDetails AttributeSetDetails;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable, DisplayName=" └─ Attribute", EditCondition="!bUseStagedPoints && CollectionSource == EPCGExCollectionSource::Attribute", EditConditionHides))
 	FName CollectionPathAttributeName = "CollectionPath";
@@ -230,7 +231,7 @@ struct FPCGExPathSplineMeshContext final : FPCGExPathProcessorContext
 
 	TSharedPtr<PCGEx::TAssetLoader<UPCGExAssetCollection>> CollectionsLoader;
 
-	TObjectPtr<UPCGExMeshCollection> MainCollection;
+	TObjectPtr<UPCGExAssetCollection> MainCollection;
 
 	const UPCGExSelectorFactoryData* SelectorFactory = nullptr;
 

--- a/Source/PCGExProperties/Private/PCGExProperties.cpp
+++ b/Source/PCGExProperties/Private/PCGExProperties.cpp
@@ -42,6 +42,35 @@ int32 PCGExProperties::GetPackedFloatWidth(const EPCGMetadataTypes InType)
 	}
 }
 
+bool PCGExProperties::MakePropertyForMetadataType(const EPCGMetadataTypes InType, const FName InPropertyName, FInstancedStruct& OutProperty)
+{
+	switch (InType)
+	{
+#define PCGEX_MAKE_PROPERTY_CASE(_TYPE, _STRUCT) case EPCGMetadataTypes::_TYPE: OutProperty.InitializeAs<_STRUCT>(); break;
+	PCGEX_MAKE_PROPERTY_CASE(Float, FPCGExProperty_Float)
+	PCGEX_MAKE_PROPERTY_CASE(Double, FPCGExProperty_Double)
+	PCGEX_MAKE_PROPERTY_CASE(Integer32, FPCGExProperty_Int32)
+	PCGEX_MAKE_PROPERTY_CASE(Integer64, FPCGExProperty_Int64)
+	PCGEX_MAKE_PROPERTY_CASE(Vector2, FPCGExProperty_Vector2)
+	PCGEX_MAKE_PROPERTY_CASE(Vector, FPCGExProperty_Vector)
+	PCGEX_MAKE_PROPERTY_CASE(Vector4, FPCGExProperty_Vector4)
+	PCGEX_MAKE_PROPERTY_CASE(Quaternion, FPCGExProperty_Quat)
+	PCGEX_MAKE_PROPERTY_CASE(Transform, FPCGExProperty_Transform)
+	PCGEX_MAKE_PROPERTY_CASE(String, FPCGExProperty_String)
+	PCGEX_MAKE_PROPERTY_CASE(Boolean, FPCGExProperty_Bool)
+	PCGEX_MAKE_PROPERTY_CASE(Rotator, FPCGExProperty_Rotator)
+	PCGEX_MAKE_PROPERTY_CASE(Name, FPCGExProperty_Name)
+	PCGEX_MAKE_PROPERTY_CASE(SoftObjectPath, FPCGExProperty_SoftObjectPath)
+	PCGEX_MAKE_PROPERTY_CASE(SoftClassPath, FPCGExProperty_SoftClassPath)
+#undef PCGEX_MAKE_PROPERTY_CASE
+	default:
+		return false;
+	}
+
+	OutProperty.GetMutablePtr<FPCGExProperty>()->PropertyName = InPropertyName;
+	return true;
+}
+
 int32 FPCGExProperty::GetPackedFloatCount() const
 {
 	return PCGExProperties::GetPackedFloatWidth(GetOutputType());

--- a/Source/PCGExProperties/Public/PCGExProperty.h
+++ b/Source/PCGExProperties/Public/PCGExProperty.h
@@ -476,6 +476,13 @@ namespace PCGExProperties
 	PCGEXPROPERTIES_API int32 GetPackedFloatWidth(EPCGMetadataTypes InType);
 
 	/**
+	 * Initialize OutProperty as the property type storing a value of InType, named InPropertyName
+	 * (HeaderId left at 0 -- schema sync mints it). The 15 legacy PCG attribute types map 1:1; false
+	 * for every other type (Byte/Text/Enum/Struct/Object attributes have no property counterpart).
+	 */
+	PCGEXPROPERTIES_API bool MakePropertyForMetadataType(EPCGMetadataTypes InType, FName InPropertyName, FInstancedStruct& OutProperty);
+
+	/**
 	 * Get first property of specified type, optionally filtered by name.
 	 * @param Properties - Array view of FInstancedStruct containing properties
 	 * @param PropertyName - Optional name filter (NAME_None matches any)


### PR DESCRIPTION
Introduce roaming Omni collections and attribute-set builds with registry-driven per-row type resolution.

Key changes:
- New PCGExCollectionHelpers::FSourceAssetResolver to resolve asset rows/paths via the type registry.
- ResolveActorClassPath for actor/blueprint class detection.
- BuildFromAttributeSet now infers entry types, appends entries via AddEntryOfType, and maps extra attributes to collection property schema.
- Added MakePropertyForMetadataType to create property structs from metadata types.
- Default staging bounds for non-runtime-stageable types and related warnings.
- BuildAssetCollection now creates transient Omni collections; spline mesh accepts any collection host.

Various editor/runtime guards and staging fixes included.